### PR TITLE
Added ccflag to allow multiple definitions and synched native-sdk and cv-sdk

### DIFF
--- a/web-server/monkey.patch
+++ b/web-server/monkey.patch
@@ -1,3 +1,16 @@
+diff --git a/configure b/configure
+index 4286c34..b4301fa 100644
+--- a/configure
++++ b/configure
+@@ -1297,7 +1297,7 @@ fi
+ 
+ [ -n "$relaxed_plugins" ] && DEFS="$DEFS -DRELAXED_PLUGINS"
+ 
+-CFLAGS_GEN=" -std=gnu99 -Wall -Wextra"
++CFLAGS_GEN=" -std=gnu99 -Wall -Wextra -fcommon"
+ if test -z "$debug" ; then
+ 	CFLAGS="$CFLAGS $CFLAGS_GEN -fvisibility=hidden"
+ 
 diff --git a/examples/Makefile b/examples/Makefile
 index 4bcf670f..20aed5ba 100644
 --- a/examples/Makefile

--- a/web-server/monkey.patch
+++ b/web-server/monkey.patch
@@ -216,3 +216,23 @@ index 9914cb79..383f841f 100644
  
  	mklib_stop(ctx);
  
+diff --git a/src/mk_server.c b/src/mk_server.c
+index 8c27742..956f7ee 100644
+--- a/src/mk_server.c
++++ b/src/mk_server.c
+@@ -40,11 +40,9 @@
+ unsigned int mk_server_worker_capacity(unsigned short nworkers)
+ {
+     unsigned int max, avl;
+-    struct rlimit lim;
+-
+-    /* Limit by system */
+-    getrlimit(RLIMIT_NOFILE, &lim);
+-    max = lim.rlim_cur;
++    
++    /* Overwrite the value for RLIMIT_NOFILE to avoid unmanagable memory allocation */
++    max = 1048576;
+ 
+     /* Minimum of fds needed by Monkey:
+      * --------------------------------
+ 


### PR DESCRIPTION
### Describe your changes

There was a change in gcc 10 that doesn't allow multiple definitions of variables in different files.
Also, added another change (RLIMIT_NOFILE) to synch with acap-computer-vision-sdk-example.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
