### PR TITLE
Improved text to reduce interpretation ambiguity

### DIFF
--- a/web-server/README.md
+++ b/web-server/README.md
@@ -82,7 +82,7 @@ docker run --rm web-server:$ARCH eap-install.sh $DEVICE_IP $PASS remove
 
 ## C API Examples
 
-Some C API examples are included in the app folder. To build any of the examples, use the build and install procedure as described above after making following changes to the build files:
+When you build the code, Some C API examples shall be copied into the app directory inside the build container. To build any of the examples, use the build and install procedure as described above after making following changes to the build files:
 
 1. app/manifest.json: Replace AppName "monkey" with the name of the example: hello, list or quiz
 2. Dockerfile: Replace monkey in /usr/local/packages/monkey with the name of the example: hello, list or quiz


### PR DESCRIPTION
The original text 'Some C API examples are included in the app folder' is misleading and is implying to the reader to look/search for examples directly under axis repo 'web-server/app' directory itself and complain as examples missing. But in reality, those examples are available (as part of build procedure coded in Dockerfile) inside the container and hence suggested text is trying to address that concern.

Closes AxisCommunications/acap-native-sdk-examples#87