### PR TITLE
Update incorrect SDK documentation links

### DIFF
--- a/licensekey/README.md
+++ b/licensekey/README.md
@@ -6,7 +6,7 @@ This README file explains how to build an ACAP application that uses the license
 
 Together with this README file, you should be able to find a directory called app. That directory contains the application source code which can easily be compiled and run with the help of the tools and step by step below.
 
-This example illustrates how to check the license key status. A license key is a signed file which has been generated for a specific device ID and application ID. The ACAP Service Portal is maintaining both license keys and application IDs, see [Online manual](https://help.axis.com/acap-3-developer-guide#acap-service-portal-for-administrators)
+This example illustrates how to check the license key status. A license key is a signed file which has been generated for a specific device ID and application ID. The ACAP Service Portal is maintaining both license keys and application IDs, see [Online manual](https://axiscommunications.github.io/acap-documentation/docs/service/acap-service-portal.html)
 
 License key status i.e. valid or invalid is logged in the Application log.
 
@@ -133,13 +133,13 @@ or by clicking on the "**App log**" link in the device GUI.
 10:31:43.058 [ INFO ] licensekey_handler[14660]: Licensekey is invalid
 ```
 
-A valid license key for a registered application ID is only accessible through ACAP Service Portal, see [Online manual](https://help.axis.com/acap-3-developer-guide#acap-service-portal-for-administrators).
+A valid license key for a registered application ID is only accessible through ACAP Service Portal, see [Online manual](https://axiscommunications.github.io/acap-documentation/docs/service/acap-service-portal.html).
 
 Support for installing license key though device web page is available, if acapPackageConf.copyProtection.method is set to "axis" in the **manifest.json** file, by the following steps:
 
 *Goto your device web page above > Click on the tab **Apps** in the device GUI > Click on the installed **licensekey_handler** application > Install the license with the **Install** button in the **Activate the license** part*
 
-More instructions how to install a valid license key is found on [Axis Developer Community](https://help.axis.com/acap-3-developer-guide#developer-community).
+More instructions how to install a valid license key is found on [Axis Developer Community](https://www.axis.com/developer-community).
 
 ## License
 

--- a/vdo-opencl-filtering/README.md
+++ b/vdo-opencl-filtering/README.md
@@ -37,7 +37,7 @@ vdo-opencl-filtering
 
 The example is done for a captured video stream in YUV NV12 format. For different stream formats the OpenCL program must be altered.
 
-This example requires OpenCL 1.2 with GPU accelleration, see [SDK user manual](https://help.axis.com/acap-3-developer-guide#open-standard-apis).
+This example requires OpenCL 1.2 with GPU accelleration, see [SDK user manual](https://axiscommunications.github.io/acap-documentation/docs/api/native-sdk-api.html#opencl).
 
 ### How to run the code
 


### PR DESCRIPTION
Wrong ACAP SDK documentation version referenced
* Change to general developer community link
* Use counter-part for ACAP Portal and OpenCL