### PR TITLE
container-example: pass --env-file parameter to docker compose down

### DIFF
--- a/container-example/containerExample
+++ b/container-example/containerExample
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 stop_containers()  {
-  docker compose down
+  docker compose --env-file "./env.config" down
   exit 0
 }
 


### PR DESCRIPTION
### Describe your changes

In container-example/containerExample script, pass --env-file "./env.config" parameter to the docker compose down command. Without this, the compose down command misses the ALPINE_IMAGE variable definition and fails, leaving the container up and running. 

Patch tested on a Q1656 Box device, firmware 11.4.63, with "Docker Compose" ACAP v1.3.0.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
