### PR TITLE
Fix segfault in fastcgi app

### DIFF
--- a/web-server-using-fastcgi/app/fastcgi_example.c
+++ b/web-server-using-fastcgi/app/fastcgi_example.c
@@ -73,7 +73,7 @@ int fcgi_run() {
         FCGX_FPrintF(request.out, "<h1>Hello ");
 
         // Parse the uri and the query string
-        char* uriString = FCGX_GetParam("REQUEST_URI", request.envp);
+        const char* uriString = FCGX_GetParam("REQUEST_URI", request.envp);
 
         UriUriA uri;
         UriQueryListA* queryList;
@@ -86,6 +86,8 @@ int fcgi_run() {
         if (uriParseSingleUriA(&uri, uriString, &errorPos) != URI_SUCCESS) {
             /* Failure (no need to call uriFreeUriMembersA) */
             FCGX_FPrintF(request.out, "Failed to parse URI");
+            FCGX_Finish_r(&request);
+            continue;
         }
 
         syslog(LOG_INFO, "URI: %s", uriString);
@@ -95,6 +97,9 @@ int fcgi_run() {
             URI_SUCCESS) {
             /* Failure */
             FCGX_FPrintF(request.out, "Failed to parse query");
+            FCGX_Finish_r(&request);
+            uriFreeUriMembersA(&uri);
+            continue;
         }
 
         // Find and print the name parameter in the query string


### PR DESCRIPTION
If there are no query parameters specified, the application segfaulted since it did continue to try using the uri query list even if parsing them failed. This commit causes it to print the "Failed to parse .." text and then continue, waiting for the next request.

### Describe your changes

Correct error handling.

### Issue ticket number and link

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Maintainer notes

- [x] I have added tests that prove that the fix is effective
- [x] I have verified that the code change follows the style already available in the repository

