### PR TITLE
clang-format: Change line break of function arguments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,13 +3,17 @@
 BasedOnStyle:  LLVM
 # Cpp covers both C and C++.
 Language:        Cpp
-AlignConsecutiveMacros: Consecutive
 AlignConsecutiveAssignments: Consecutive
 AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveMacros: Consecutive
 AlignEscapedNewlines: Left
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: false
+BinPackParameters: false
 ColumnLimit:     100
 IndentCaseLabels: true
 # Most files have used this indentation width and to not get to large diffs

--- a/axevent/send_event/app/send_event.c
+++ b/axevent/send_event/app/send_event.c
@@ -53,8 +53,12 @@ static gboolean send_event(AppData* app_data) {
 
     // Add the variable elements of the event to the set
     syslog(LOG_INFO, "Add value: %lf", app_data->value);
-    ax_event_key_value_set_add_key_value(key_value_set, "Value", NULL, &app_data->value,
-                                         AX_VALUE_TYPE_DOUBLE, NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "Value",
+                                         NULL,
+                                         &app_data->value,
+                                         AX_VALUE_TYPE_DOUBLE,
+                                         NULL);
 
     // Create the event
     // Use ax_event_new2 since ax_event_new is deprecated from 3.2
@@ -126,26 +130,51 @@ static guint setup_declaration(AXEventHandler* event_handler) {
 
     // Create keys, namespaces and nice names for the event
     key_value_set = ax_event_key_value_set_new();
-    ax_event_key_value_set_add_key_value(key_value_set, "topic0", "tns1", "Monitoring",
-                                         AX_VALUE_TYPE_STRING, NULL);
-    ax_event_key_value_set_add_key_value(key_value_set, "topic1", "tns1", "ProcessorUsage",
-                                         AX_VALUE_TYPE_STRING, NULL);
-    ax_event_key_value_set_add_key_value(key_value_set, "Token", NULL, &token, AX_VALUE_TYPE_INT,
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "topic0",
+                                         "tns1",
+                                         "Monitoring",
+                                         AX_VALUE_TYPE_STRING,
                                          NULL);
-    ax_event_key_value_set_add_key_value(key_value_set, "Value", NULL, &start_value,
-                                         AX_VALUE_TYPE_DOUBLE, NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "topic1",
+                                         "tns1",
+                                         "ProcessorUsage",
+                                         AX_VALUE_TYPE_STRING,
+                                         NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "Token",
+                                         NULL,
+                                         &token,
+                                         AX_VALUE_TYPE_INT,
+                                         NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "Value",
+                                         NULL,
+                                         &start_value,
+                                         AX_VALUE_TYPE_DOUBLE,
+                                         NULL);
     ax_event_key_value_set_mark_as_source(key_value_set, "Token", NULL, NULL);
-    ax_event_key_value_set_mark_as_user_defined(key_value_set, "Token", NULL,
-                                                "wstype:tt:ReferenceToken", NULL);
+    ax_event_key_value_set_mark_as_user_defined(key_value_set,
+                                                "Token",
+                                                NULL,
+                                                "wstype:tt:ReferenceToken",
+                                                NULL);
     ax_event_key_value_set_mark_as_data(key_value_set, "Value", NULL, NULL);
-    ax_event_key_value_set_mark_as_user_defined(key_value_set, "Value", NULL, "wstype:xs:float",
+    ax_event_key_value_set_mark_as_user_defined(key_value_set,
+                                                "Value",
+                                                NULL,
+                                                "wstype:xs:float",
                                                 NULL);
 
     // Declare event
-    if (!ax_event_handler_declare(event_handler, key_value_set,
+    if (!ax_event_handler_declare(event_handler,
+                                  key_value_set,
                                   FALSE,  // Indicate a property state event
-                                  &declaration, (AXDeclarationCompleteCallback)declaration_complete,
-                                  &start_value, &error)) {
+                                  &declaration,
+                                  (AXDeclarationCompleteCallback)declaration_complete,
+                                  &start_value,
+                                  &error)) {
         syslog(LOG_WARNING, "Could not declare: %s", error->message);
         g_error_free(error);
     }

--- a/axevent/subscribe_to_event/app/subscribe_to_event.c
+++ b/axevent/subscribe_to_event/app/subscribe_to_event.c
@@ -84,17 +84,29 @@ static guint onviftrigger_subscription(AXEventHandler* event_handler, guint* tok
     key_value_set = ax_event_key_value_set_new();
 
     // Set keys and namespaces for the event to be subscribed
-    ax_event_key_value_set_add_key_value(key_value_set, "topic0", "tns1", "Monitoring",
-                                         AX_VALUE_TYPE_STRING, NULL);
-    ax_event_key_value_set_add_key_value(key_value_set, "topic1", "tns1", "ProcessorUsage",
-                                         AX_VALUE_TYPE_STRING, NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "topic0",
+                                         "tns1",
+                                         "Monitoring",
+                                         AX_VALUE_TYPE_STRING,
+                                         NULL);
+    ax_event_key_value_set_add_key_value(key_value_set,
+                                         "topic1",
+                                         "tns1",
+                                         "ProcessorUsage",
+                                         AX_VALUE_TYPE_STRING,
+                                         NULL);
 
     /*
      * Time to setup the subscription. Use the "token" input argument as
      * input data to the callback function "subscription callback"
      */
-    ax_event_handler_subscribe(event_handler, key_value_set, &subscription,
-                               (AXSubscriptionCallback)subscription_callback, token, NULL);
+    ax_event_handler_subscribe(event_handler,
+                               key_value_set,
+                               &subscription,
+                               (AXSubscriptionCallback)subscription_callback,
+                               token,
+                               NULL);
 
     syslog(LOG_INFO, "And here's the token: %d", *token);
 

--- a/axevent/subscribe_to_events/app/subscribe_to_events.c
+++ b/axevent/subscribe_to_events/app/subscribe_to_events.c
@@ -84,12 +84,14 @@ static void common_callback(guint subscription, AXEvent* event, guint* token) {
             syslog(LOG_INFO,
                    "%d:audiotrigger-event: Audio channel %d above "
                    "trigger level",
-                   *token, channel);
+                   *token,
+                   channel);
         } else {
             syslog(LOG_INFO,
                    "%d:audiotrigger-event: Audio channel %d below "
                    "trigger level",
-                   *token, channel);
+                   *token,
+                   channel);
         }
 
     } else if (*token == DAYNIGHT_TOKEN) {
@@ -112,7 +114,9 @@ static void common_callback(guint subscription, AXEvent* event, guint* token) {
         if (state) {
             syslog(LOG_INFO, "%d:manualtrigger-event: Trigger on port %d is active", *token, port);
         } else {
-            syslog(LOG_INFO, "%d:manualtrigger-event: Trigger on port %d is inactive", *token,
+            syslog(LOG_INFO,
+                   "%d:manualtrigger-event: Trigger on port %d is inactive",
+                   *token,
                    port);
         }
 
@@ -155,7 +159,10 @@ static void ptzmove_callback(guint subscription, AXEvent* event, ptzmove* data) 
     key_value_set = ax_event_get_key_value_set(event);
 
     // Get the state of the manual trigger port
-    ax_event_key_value_set_get_integer(key_value_set, "PTZConfigurationToken", NULL, &channel,
+    ax_event_key_value_set_get_integer(key_value_set,
+                                       "PTZConfigurationToken",
+                                       NULL,
+                                       &channel,
                                        NULL);
     ax_event_key_value_set_get_boolean(key_value_set, "is_moving", NULL, &is_moving, NULL);
 
@@ -163,8 +170,12 @@ static void ptzmove_callback(guint subscription, AXEvent* event, ptzmove* data) 
     if (is_moving) {
         data->ptzchannel[channel].num_moves += 1;
         val = (data->ptzchannel[channel].num_moves == 1);
-        syslog(LOG_INFO, "%d:ptzmove-event: PTZ channel %d started moving (%d %s)", data->id,
-               channel, data->ptzchannel[channel].num_moves, val ? "time" : "times");
+        syslog(LOG_INFO,
+               "%d:ptzmove-event: PTZ channel %d started moving (%d %s)",
+               data->id,
+               channel,
+               data->ptzchannel[channel].num_moves,
+               val ? "time" : "times");
     } else {
         if (data->ptzchannel[channel].num_moves > 0) {
             syslog(LOG_INFO, "%d:ptzmove-event: PTZ channel %d stopped moving", data->id, channel);
@@ -202,10 +213,25 @@ static guint audiotrigger_subscription(AXEventHandler* event_handler, guint toke
      *        channel=NULL    <-- Subscribe to all channels
      *      triggered=NULL    <-- Subscribe to all states
      */
-    ax_event_key_value_set_add_key_values(
-        key_value_set, NULL, "topic0", "tns1", "AudioSource", AX_VALUE_TYPE_STRING, "topic1",
-        "tnsaxis", "TriggerLevel", AX_VALUE_TYPE_STRING, "channel", NULL, NULL, AX_VALUE_TYPE_INT,
-        "triggered", NULL, NULL, AX_VALUE_TYPE_BOOL, NULL);
+    ax_event_key_value_set_add_key_values(key_value_set,
+                                          NULL,
+                                          "topic0",
+                                          "tns1",
+                                          "AudioSource",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic1",
+                                          "tnsaxis",
+                                          "TriggerLevel",
+                                          AX_VALUE_TYPE_STRING,
+                                          "channel",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_INT,
+                                          "triggered",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_BOOL,
+                                          NULL);
 
     // Setup subscription and connect to callback function
     ax_event_handler_subscribe(event_handler,                            // event handler
@@ -245,10 +271,25 @@ static guint daynight_subscription(AXEventHandler* event_handler, guint token) {
      * VideoSource...=NULL    <-- Subscribe to all values
      *            day=NULL    <-- Subscribe to all states
      */
-    ax_event_key_value_set_add_key_values(
-        key_value_set, NULL, "topic0", "tns1", "VideoSource", AX_VALUE_TYPE_STRING, "topic1",
-        "tnsaxis", "DayNightVision", AX_VALUE_TYPE_STRING, "VideoSourceConfigurationToken", NULL,
-        NULL, AX_VALUE_TYPE_INT, "day", NULL, NULL, AX_VALUE_TYPE_BOOL, NULL);
+    ax_event_key_value_set_add_key_values(key_value_set,
+                                          NULL,
+                                          "topic0",
+                                          "tns1",
+                                          "VideoSource",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic1",
+                                          "tnsaxis",
+                                          "DayNightVision",
+                                          AX_VALUE_TYPE_STRING,
+                                          "VideoSourceConfigurationToken",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_INT,
+                                          "day",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_BOOL,
+                                          NULL);
 
     // Setup subscription and connect to callback function
     ax_event_handler_subscribe(event_handler,                            // event handler
@@ -290,10 +331,29 @@ static guint manualtrigger_subscription(AXEventHandler* event_handler, guint tok
      *           port=&port    <-- Subscribe to port number 1
      *          state=NULL     <-- Subscribe to all states
      */
-    ax_event_key_value_set_add_key_values(
-        key_value_set, NULL, "topic0", "tns1", "Device", AX_VALUE_TYPE_STRING, "topic1", "tnsaxis",
-        "IO", AX_VALUE_TYPE_STRING, "topic2", "tnsaxis", "VirtualPort", AX_VALUE_TYPE_STRING,
-        "port", NULL, &port, AX_VALUE_TYPE_INT, "state", NULL, NULL, AX_VALUE_TYPE_BOOL, NULL);
+    ax_event_key_value_set_add_key_values(key_value_set,
+                                          NULL,
+                                          "topic0",
+                                          "tns1",
+                                          "Device",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic1",
+                                          "tnsaxis",
+                                          "IO",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic2",
+                                          "tnsaxis",
+                                          "VirtualPort",
+                                          AX_VALUE_TYPE_STRING,
+                                          "port",
+                                          NULL,
+                                          &port,
+                                          AX_VALUE_TYPE_INT,
+                                          "state",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_BOOL,
+                                          NULL);
 
     // Setup subscription and connect to callback function
     ax_event_handler_subscribe(event_handler,                            // event handler
@@ -333,10 +393,25 @@ static guint ptzmove_subscription(AXEventHandler* event_handler, ptzmove* data) 
      *        channel=NULL    <-- Subscribe to all PTZ channels
      *      is_moving=NULL    <-- Subscribe to all values
      */
-    ax_event_key_value_set_add_key_values(
-        key_value_set, NULL, "topic0", "tns1", "PTZController", AX_VALUE_TYPE_STRING, "topic1",
-        "tnsaxis", "Move", AX_VALUE_TYPE_STRING, "PTZConfigurationToken", NULL, NULL,
-        AX_VALUE_TYPE_INT, "is_moving", NULL, NULL, AX_VALUE_TYPE_BOOL, NULL);
+    ax_event_key_value_set_add_key_values(key_value_set,
+                                          NULL,
+                                          "topic0",
+                                          "tns1",
+                                          "PTZController",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic1",
+                                          "tnsaxis",
+                                          "Move",
+                                          AX_VALUE_TYPE_STRING,
+                                          "PTZConfigurationToken",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_INT,
+                                          "is_moving",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_BOOL,
+                                          NULL);
 
     // Setup subscription and connect to callback function
     ax_event_handler_subscribe(event_handler,                             // event handler
@@ -377,10 +452,25 @@ static guint tampering_subscription(AXEventHandler* event_handler, guint token) 
      *        channel=&channel    <-- Subscribe to channel number 1
      *      tampering=NULL        <-- Subscribe to all values
      */
-    ax_event_key_value_set_add_key_values(
-        key_value_set, NULL, "topic0", "tns1", "VideoSource", AX_VALUE_TYPE_STRING, "topic1",
-        "tnsaxis", "Tampering", AX_VALUE_TYPE_STRING, "channel", NULL, &channel, AX_VALUE_TYPE_INT,
-        "tampering", NULL, NULL, AX_VALUE_TYPE_INT, NULL);
+    ax_event_key_value_set_add_key_values(key_value_set,
+                                          NULL,
+                                          "topic0",
+                                          "tns1",
+                                          "VideoSource",
+                                          AX_VALUE_TYPE_STRING,
+                                          "topic1",
+                                          "tnsaxis",
+                                          "Tampering",
+                                          AX_VALUE_TYPE_STRING,
+                                          "channel",
+                                          NULL,
+                                          &channel,
+                                          AX_VALUE_TYPE_INT,
+                                          "tampering",
+                                          NULL,
+                                          NULL,
+                                          AX_VALUE_TYPE_INT,
+                                          NULL);
 
     // Setup subscription and connect to callback function
     ax_event_handler_subscribe(event_handler,                            // event handler

--- a/axoverlay/app/axoverlay.c
+++ b/axoverlay/app/axoverlay.c
@@ -76,8 +76,13 @@ static gdouble index2cairo(const gint color_index) {
  * param color_index Palette color index.
  * param line_width Rectange line width.
  */
-static void draw_rectangle(cairo_t* context, gint left, gint top, gint right, gint bottom,
-                           gint color_index, gint line_width) {
+static void draw_rectangle(cairo_t* context,
+                           gint left,
+                           gint top,
+                           gint right,
+                           gint bottom,
+                           gint color_index,
+                           gint line_width) {
     gdouble val = 0;
 
     val = index2cairo(color_index);
@@ -153,8 +158,8 @@ static void setup_axoverlay_data(struct axoverlay_overlay_data* data) {
  *
  * return result as boolean
  */
-static gboolean setup_palette_color(const int index, const gint r, const gint g, const gint b,
-                                    const gint a) {
+static gboolean
+setup_palette_color(const int index, const gint r, const gint g, const gint b, const gint a) {
     GError* error = NULL;
     struct axoverlay_palette_color color;
 
@@ -192,9 +197,13 @@ static gboolean setup_palette_color(const int index, const gint r, const gint g,
  * param overlay_height Overlay height.
  * param user_data Optional user data associated with this overlay.
  */
-static void adjustment_cb(const gint id, const struct axoverlay_stream_data* stream,
-                          enum axoverlay_position_type* postype, gfloat* overlay_x,
-                          gfloat* overlay_y, gint* overlay_width, gint* overlay_height,
+static void adjustment_cb(const gint id,
+                          const struct axoverlay_stream_data* stream,
+                          enum axoverlay_position_type* postype,
+                          gfloat* overlay_x,
+                          gfloat* overlay_y,
+                          gint* overlay_width,
+                          gint* overlay_height,
                           gpointer user_data) {
     syslog(LOG_INFO, "Adjust callback for overlay: %i x %i", *overlay_width, *overlay_height);
     syslog(LOG_INFO, "Adjust callback for stream: %i x %i", stream->width, stream->height);
@@ -220,11 +229,15 @@ static void adjustment_cb(const gint id, const struct axoverlay_stream_data* str
  * param overlay_height Overlay height.
  * param user_data Optional user data associated with this overlay.
  */
-static void render_overlay_cb(gpointer rendering_context, const gint id,
+static void render_overlay_cb(gpointer rendering_context,
+                              const gint id,
                               const struct axoverlay_stream_data* stream,
-                              const enum axoverlay_position_type postype, const gfloat overlay_x,
-                              const gfloat overlay_y, const gint overlay_width,
-                              const gint overlay_height, const gpointer user_data) {
+                              const enum axoverlay_position_type postype,
+                              const gfloat overlay_x,
+                              const gfloat overlay_y,
+                              const gint overlay_width,
+                              const gint overlay_height,
+                              const gpointer user_data) {
     gdouble val = FALSE;
 
     syslog(LOG_INFO, "Render callback for camera: %i", stream->camera);
@@ -243,8 +256,13 @@ static void render_overlay_cb(gpointer rendering_context, const gint id,
         draw_rectangle(rendering_context, 0, 0, stream->width, stream->height / 4, top_color, 9.6);
 
         //  Draw a bottom rectangle in toggling color
-        draw_rectangle(rendering_context, 0, stream->height * 3 / 4, stream->width, stream->height,
-                       bottom_color, 2.0);
+        draw_rectangle(rendering_context,
+                       0,
+                       stream->height * 3 / 4,
+                       stream->width,
+                       stream->height,
+                       bottom_color,
+                       2.0);
     } else if (id == overlay_id_text) {
         //  Show text in black
         draw_text(rendering_context, stream->width / 2, stream->height / 2);

--- a/axserialport/app/axserialport.c
+++ b/axserialport/app/axserialport.c
@@ -157,7 +157,9 @@ static gboolean send_timer_data(gpointer data) {
         /* Flush the write buffer */
         ret = g_io_channel_flush(iochannel, &error);
         /* Log the return status from g_io_channel_write_chars() */
-        g_message("%s() wrote %d bytes, status:'%s'", __FUNCTION__, bytes_written,
+        g_message("%s() wrote %d bytes, status:'%s'",
+                  __FUNCTION__,
+                  bytes_written,
                   iostatus2str(ret));
     }
 

--- a/axstorage/app/axstorage.c
+++ b/axstorage/app/axstorage.c
@@ -162,7 +162,9 @@ static void free_disk_item_t() {
                before releasing the storage device. */
             ax_storage_release_async(item->storage, release_disk_cb, item->storage_id, &error);
             if (error != NULL) {
-                syslog(LOG_WARNING, "Failed to release %s. Error: %s", item->storage_id,
+                syslog(LOG_WARNING,
+                       "Failed to release %s. Error: %s",
+                       item->storage_id,
                        error->message);
                 g_clear_error(&error);
             } else {
@@ -173,7 +175,9 @@ static void free_disk_item_t() {
 
         ax_storage_unsubscribe(item->subscription_id, &error);
         if (error != NULL) {
-            syslog(LOG_WARNING, "Failed to unsubscribe event of %s. Error: %s", item->storage_id,
+            syslog(LOG_WARNING,
+                   "Failed to unsubscribe event of %s. Error: %s",
+                   item->storage_id,
                    error->message);
             g_clear_error(&error);
         } else {
@@ -266,7 +270,9 @@ static void subscribe_cb(gchar* storage_id, gpointer user_data, GError* error) {
     /* Get the status of the events. */
     exiting = ax_storage_get_status(storage_id, AX_STORAGE_EXITING_EVENT, &ax_error);
     if (ax_error != NULL) {
-        syslog(LOG_WARNING, "Failed to get EXITING event for %s. Error: %s", storage_id,
+        syslog(LOG_WARNING,
+               "Failed to get EXITING event for %s. Error: %s",
+               storage_id,
                ax_error->message);
         g_error_free(ax_error);
         return;
@@ -274,7 +280,9 @@ static void subscribe_cb(gchar* storage_id, gpointer user_data, GError* error) {
 
     available = ax_storage_get_status(storage_id, AX_STORAGE_AVAILABLE_EVENT, &ax_error);
     if (ax_error != NULL) {
-        syslog(LOG_WARNING, "Failed to get AVAILABLE event for %s. Error: %s", storage_id,
+        syslog(LOG_WARNING,
+               "Failed to get AVAILABLE event for %s. Error: %s",
+               storage_id,
                ax_error->message);
         g_error_free(ax_error);
         return;
@@ -282,7 +290,9 @@ static void subscribe_cb(gchar* storage_id, gpointer user_data, GError* error) {
 
     writable = ax_storage_get_status(storage_id, AX_STORAGE_WRITABLE_EVENT, &ax_error);
     if (ax_error != NULL) {
-        syslog(LOG_WARNING, "Failed to get WRITABLE event for %s. Error: %s", storage_id,
+        syslog(LOG_WARNING,
+               "Failed to get WRITABLE event for %s. Error: %s",
+               storage_id,
                ax_error->message);
         g_error_free(ax_error);
         return;
@@ -290,7 +300,9 @@ static void subscribe_cb(gchar* storage_id, gpointer user_data, GError* error) {
 
     full = ax_storage_get_status(storage_id, AX_STORAGE_FULL_EVENT, &ax_error);
     if (ax_error != NULL) {
-        syslog(LOG_WARNING, "Failed to get FULL event for %s. Error: %s", storage_id,
+        syslog(LOG_WARNING,
+               "Failed to get FULL event for %s. Error: %s",
+               storage_id,
                ax_error->message);
         g_error_free(ax_error);
         return;
@@ -301,8 +313,12 @@ static void subscribe_cb(gchar* storage_id, gpointer user_data, GError* error) {
     disk->exiting   = exiting;
     disk->full      = full;
 
-    syslog(LOG_INFO, "Status of events for %s: %swritable, %savailable, %sexiting, %sfull",
-           storage_id, writable ? "" : "not ", available ? "" : "not ", exiting ? "" : "not ",
+    syslog(LOG_INFO,
+           "Status of events for %s: %swritable, %savailable, %sexiting, %sfull",
+           storage_id,
+           writable ? "" : "not ",
+           available ? "" : "not ",
+           exiting ? "" : "not ",
            full ? "" : "not ");
 
     /* If exiting, and the disk was set up before, release it. */
@@ -349,7 +365,9 @@ static disk_item_t* new_disk_item_t(gchar* storage_id) {
     /* Subscribe to disks events. */
     subscription_id = ax_storage_subscribe(storage_id, subscribe_cb, NULL, &error);
     if (subscription_id == 0 || error != NULL) {
-        syslog(LOG_ERR, "Failed to subscribe to events of %s. Error: %s", storage_id,
+        syslog(LOG_ERR,
+               "Failed to subscribe to events of %s. Error: %s",
+               storage_id,
                error->message);
         g_clear_error(&error);
         return NULL;

--- a/object-detection-cv25/app/argparse.c
+++ b/object-detection-cv25/app/argparse.c
@@ -29,7 +29,10 @@ static int parsePosInt(char* arg, unsigned long long* i, unsigned long long limi
 static int parseOpt(int key, char* arg, struct argp_state* state);
 
 const struct argp_option opts[] = {
-    {"chip", 'c', "CHIP", 0,
+    {"chip",
+     'c',
+     "CHIP",
+     0,
      "Chooses chip CHIP to run on, where CHIP is the enum type larodChip "
      "from the library. If not specified, the default chip for a new "
      "connection will be used.",

--- a/object-detection-cv25/app/imgprovider.c
+++ b/object-detection-cv25/app/imgprovider.c
@@ -91,8 +91,8 @@ static void releaseVdoBuffers(ImgProvider_t* provider);
  */
 static void* threadEntry(void* data);
 
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat format) {
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat format) {
     bool mtxInitialized  = false;
     bool condInitialized = false;
 
@@ -112,7 +112,9 @@ ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int nu
     mtxInitialized = true;
 
     if (pthread_cond_init(&provider->frameDeliverCond, NULL)) {
-        syslog(LOG_ERR, "%s: Unable to initialize condition variable: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Unable to initialize condition variable: %s",
+               __func__,
                strerror(errno));
         goto errorExit;
     }
@@ -183,7 +185,9 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
     for (size_t i = 0; i < NUM_VDO_BUFFERS; i++) {
         provider->vdoBuffers[i] = vdo_stream_buffer_alloc(vdoStream, NULL, &error);
         if (provider->vdoBuffers[i] == NULL) {
-            syslog(LOG_ERR, "%s: Failed creating VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed creating VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -193,13 +197,17 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
         // implementation.
         void* dummyPtr = vdo_buffer_get_data(provider->vdoBuffers[i]);
         if (!dummyPtr) {
-            syslog(LOG_ERR, "%s: Failed initializing buffer memmap: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed initializing buffer memmap: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
 
         if (!vdo_stream_buffer_enqueue(vdoStream, provider->vdoBuffers[i], &error)) {
-            syslog(LOG_ERR, "%s: Failed enqueue VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed enqueue VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -213,8 +221,10 @@ errorExit:
     return ret;
 }
 
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight) {
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight) {
     VdoResolutionSet* set = NULL;
     VdoChannel* channel   = NULL;
     GError* error         = NULL;
@@ -226,7 +236,9 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     // Retrieve channel resolutions
     channel = vdo_channel_get(VDO_CHANNEL, &error);
     if (!channel) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
@@ -237,7 +249,9 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     vdo_map_set_string(filter, "select", "all");
     set = vdo_channel_get_resolutions(channel, filter, &error);
     if (!set) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get_resolutions(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get_resolutions(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
@@ -264,8 +278,11 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     if (bestResolutionIdx >= 0) {
         *chosenWidth  = set->resolutions[bestResolutionIdx].width;
         *chosenHeight = set->resolutions[bestResolutionIdx].height;
-        syslog(LOG_INFO, "%s: We select stream w/h=%u x %u based on VDO channel info.\n", __func__,
-               *chosenWidth, *chosenHeight);
+        syslog(LOG_INFO,
+               "%s: We select stream w/h=%u x %u based on VDO channel info.\n",
+               __func__,
+               *chosenWidth,
+               *chosenHeight);
     } else {
         syslog(LOG_WARNING,
                "%s: VDO channel info contains no reslution info. Fallback "
@@ -305,7 +322,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     VdoStream* vdoStream = vdo_stream_new(vdoMap, NULL, &error);
     if (!vdoStream) {
-        syslog(LOG_ERR, "%s: Failed creating vdo stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed creating vdo stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -317,7 +336,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     // Start the actual VDO streaming.
     if (!vdo_stream_start(vdoStream, &error)) {
-        syslog(LOG_ERR, "%s: Failed starting stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed starting stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -388,7 +409,9 @@ static void* threadEntry(void* data) {
 
         if (!newBuffer) {
             // Fail but we continue anyway hoping for the best.
-            syslog(LOG_WARNING, "%s: Failed fetching frame from vdo: %s", __func__,
+            syslog(LOG_WARNING,
+                   "%s: Failed fetching frame from vdo: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             g_clear_error(&error);
             continue;
@@ -415,7 +438,9 @@ static void* threadEntry(void* data) {
         if (oldBuffer) {
             if (!vdo_stream_buffer_enqueue(provider->vdoStream, oldBuffer, &error)) {
                 // Fail but we continue anyway hoping for the best.
-                syslog(LOG_WARNING, "%s: Failed enqueueing buffer to vdo: %s", __func__,
+                syslog(LOG_WARNING,
+                       "%s: Failed enqueueing buffer to vdo: %s",
+                       __func__,
                        (error != NULL) ? error->message : "N/A");
                 g_clear_error(&error);
             }
@@ -428,7 +453,9 @@ static void* threadEntry(void* data) {
 
 bool startFrameFetch(ImgProvider_t* provider) {
     if (pthread_create(&provider->fetcherThread, NULL, threadEntry, provider)) {
-        syslog(LOG_ERR, "%s: Failed to start thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to start thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }
@@ -440,7 +467,9 @@ bool stopFrameFetch(ImgProvider_t* provider) {
     provider->shutDown = true;
 
     if (pthread_join(provider->fetcherThread, NULL)) {
-        syslog(LOG_ERR, "%s: Failed to join thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to join thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }

--- a/object-detection-cv25/app/imgprovider.h
+++ b/object-detection-cv25/app/imgprovider.h
@@ -70,8 +70,10 @@ typedef struct ImgProvider {
  * param chosenHeight Selected image height.
  * return False if any errors occur, otherwise true.
  */
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight);
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight);
 
 /**
  * brief Initializes and starts an ImgProvider.
@@ -86,8 +88,8 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
  * param vdoFormat Image format to be output by stream.
  * return Pointer to new ImgProvider, or NULL if failed.
  */
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat vdoFormat);
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat vdoFormat);
 
 /**
  * brief Release VDO buffers and deallocate provider.

--- a/object-detection-cv25/app/imgutils.c
+++ b/object-detection-cv25/app/imgutils.c
@@ -31,8 +31,10 @@
  * @param jpeg_size The output size of the jpeg
  * @param jpeg_buffer The output buffer of the jpeg
  */
-void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jpeg_conf,
-                    unsigned long* jpeg_size, unsigned char** jpeg_buffer) {
+void buffer_to_jpeg(unsigned char* image_buffer,
+                    struct jpeg_compress_struct* jpeg_conf,
+                    unsigned long* jpeg_size,
+                    unsigned char** jpeg_buffer) {
     struct jpeg_error_mgr jerr;
     JSAMPROW row_pointer[1];
 
@@ -60,7 +62,10 @@ void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jp
  * @param quality The desired jpeg quality (0-100)
  * @param jpeg_conf The jpeg configuration struct to modify
  */
-void set_jpeg_configuration(int width, int height, int channels, int quality,
+void set_jpeg_configuration(int width,
+                            int height,
+                            int channels,
+                            int quality,
                             struct jpeg_compress_struct* jpeg_conf) {
     // Only supports RGB and grayscale
     jpeg_create_compress(jpeg_conf);
@@ -111,8 +116,14 @@ void jpeg_to_file(char* file_name, unsigned char* buffer, unsigned long buffer_s
  * @param crop_w The width of the desired crop in pixels
  * @param crop_h The height of the desired crop in pixels
  */
-unsigned char* crop_interleaved(unsigned char* image_buffer, int image_w, int image_h, int channels,
-                                int crop_x, int crop_y, int crop_w, int crop_h) {
+unsigned char* crop_interleaved(unsigned char* image_buffer,
+                                int image_w,
+                                int image_h,
+                                int channels,
+                                int crop_x,
+                                int crop_y,
+                                int crop_w,
+                                int crop_h) {
     // This function crops out a section of an image that is located at
     // (x, y, x + w, x + h).
     // The input buffer channel layout is assumed to be interleaved

--- a/object-detection-cv25/app/imgutils.h
+++ b/object-detection-cv25/app/imgutils.h
@@ -27,8 +27,10 @@
  * @param jpeg_size The output size of the jpeg
  * @param jpeg_buffer The output buffer of the jpeg
  */
-void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jpeg_conf,
-                    unsigned long* jpeg_size, unsigned char** jpeg_buffer);
+void buffer_to_jpeg(unsigned char* image_buffer,
+                    struct jpeg_compress_struct* jpeg_conf,
+                    unsigned long* jpeg_size,
+                    unsigned char** jpeg_buffer);
 
 /**
  * @brief Inserts common values into a jpeg configuration struct
@@ -39,7 +41,10 @@ void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jp
  * @param quality The desired jpeg quality (0-100)
  * @param jpeg_conf The jpeg configuration struct to modify
  */
-void set_jpeg_configuration(int width, int height, int channels, int quality,
+void set_jpeg_configuration(int width,
+                            int height,
+                            int channels,
+                            int quality,
                             struct jpeg_compress_struct* jpeg_conf);
 
 /**
@@ -64,8 +69,14 @@ void jpeg_to_file(char* file_name, unsigned char* buffer, unsigned long buffer_s
  * @param crop_w The width of the desired crop in pixels
  * @param crop_h The height of the desired crop in pixels
  */
-unsigned char* crop_interleaved(unsigned char* image_buffer, int image_w, int image_h, int channels,
-                                int crop_x, int crop_y, int crop_w, int crop_h);
+unsigned char* crop_interleaved(unsigned char* image_buffer,
+                                int image_w,
+                                int image_h,
+                                int channels,
+                                int crop_x,
+                                int crop_y,
+                                int crop_w,
+                                int crop_h);
 
 /**
  * @brief An example of how to use the supplied utility functions

--- a/object-detection-cv25/app/object_detection.c
+++ b/object-detection-cv25/app/object_detection.c
@@ -80,8 +80,11 @@ void freeLabels(char** labelsArray, char* labelFileBuffer) {
     free(labelFileBuffer);
 }
 
-static void padImageWidth(uint8_t* srcimage, uint8_t* dstimage, unsigned int width,
-                          unsigned int height, unsigned int padding) {
+static void padImageWidth(uint8_t* srcimage,
+                          uint8_t* dstimage,
+                          unsigned int width,
+                          unsigned int height,
+                          unsigned int padding) {
     for (size_t k = 0; k < 3; k++) {
         for (size_t i = 0; i < height; i++) {
             for (size_t j = 0; j < width; j++) {
@@ -103,7 +106,9 @@ static void padImageWidth(uint8_t* srcimage, uint8_t* dstimage, unsigned int wid
  * @param numLabelsPtr Pointer to number which will store number of labels read.
  * @return False if any errors occur, otherwise true.
  */
-static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* labelsPath,
+static bool parseLabels(char*** labelsPtr,
+                        char** labelFileBuffer,
+                        const char* labelsPath,
                         size_t* numLabelsPtr) {
     // We cut off every row at 60 characters.
     const size_t LINE_MAX_LEN = 60;
@@ -113,7 +118,10 @@ static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* l
 
     struct stat fileStats = {0};
     if (stat(labelsPath, &fileStats) < 0) {
-        syslog(LOG_ERR, "%s: Unable to get stats for label file %s: %s", __func__, labelsPath,
+        syslog(LOG_ERR,
+               "%s: Unable to get stats for label file %s: %s",
+               __func__,
+               labelsPath,
                strerror(errno));
         return false;
     }
@@ -130,7 +138,10 @@ static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* l
 
     int labelsFd = open(labelsPath, O_RDONLY);
     if (labelsFd < 0) {
-        syslog(LOG_ERR, "%s: Could not open labels file %s: %s", __func__, labelsPath,
+        syslog(LOG_ERR,
+               "%s: Could not open labels file %s: %s",
+               __func__,
+               labelsPath,
                strerror(errno));
         return false;
     }
@@ -264,7 +275,10 @@ void sigintHandler(int sig) {
  * @return Positive errno style return code (zero means success).
  */
 static bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAddr, int* convFd) {
-    syslog(LOG_INFO, "%s: Setting up a temp fd with pattern %s and size %zu", __func__, fileName,
+    syslog(LOG_INFO,
+           "%s: Setting up a temp fd with pattern %s and size %zu",
+           __func__,
+           fileName,
            fileSize);
 
     int fd = mkstemp(fileName);
@@ -275,14 +289,20 @@ static bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAd
 
     // Allocate enough space in for the fd.
     if (ftruncate(fd, (off_t)fileSize) < 0) {
-        syslog(LOG_ERR, "%s: Unable to truncate temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to truncate temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }
 
     // Remove since we don't actually care about writing to the file system.
     if (unlink(fileName)) {
-        syslog(LOG_ERR, "%s: Unable to unlink from temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to unlink from temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }
@@ -322,7 +342,9 @@ error:
  * @param model Pointer to a larodModel to be obtained.
  * @return false if error has occurred, otherwise true.
  */
-static bool setupLarod(const char* chipString, const int larodModelFd, larodConnection** larodConn,
+static bool setupLarod(const char* chipString,
+                       const int larodModelFd,
+                       larodConnection** larodConn,
                        larodModel** model) {
     larodError* error       = NULL;
     larodConnection* conn   = NULL;
@@ -345,8 +367,13 @@ static bool setupLarod(const char* chipString, const int larodModelFd, larodConn
         ;
     }
     const larodDevice* dev = larodGetDevice(conn, chipString, 0, &error);
-    loadedModel = larodLoadModel(conn, larodModelFd, dev, LAROD_ACCESS_PRIVATE, "object_detection",
-                                 NULL, &error);
+    loadedModel            = larodLoadModel(conn,
+                                 larodModelFd,
+                                 dev,
+                                 LAROD_ACCESS_PRIVATE,
+                                 "object_detection",
+                                 NULL,
+                                 &error);
     if (!loadedModel) {
         syslog(LOG_ERR, "%s: Unable to load model: %s", __func__, error->msg);
         goto error;
@@ -482,13 +509,18 @@ int main(int argc, char** argv) {
     // the function to pick the best resolution
     unsigned int streamWidth  = 640;
     unsigned int streamHeight = 360;
-    syslog(LOG_INFO, "Creating VDO image provider and creating stream %d x %d", streamWidth,
+    syslog(LOG_INFO,
+           "Creating VDO image provider and creating stream %d x %d",
+           streamWidth,
            streamHeight);
     if (streamWidth < inputWidth || streamHeight < inputHeight) {
         syslog(
             LOG_ERR,
             "Warning: Stream resolution (%d x %d) should be larger than input resolution (%d x %d)",
-            streamWidth, streamHeight, inputWidth, inputHeight);
+            streamWidth,
+            streamHeight,
+            inputWidth,
+            inputHeight);
         goto end;
     }
     sdImageProvider = createImgProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
@@ -499,12 +531,16 @@ int main(int argc, char** argv) {
     syslog(LOG_INFO, "Find the best resolution to save the high resolution image");
     unsigned int widthFrameHD;
     unsigned int heightFrameHD;
-    if (!chooseStreamResolution(desiredHDImgWidth, desiredHDImgHeight, &widthFrameHD,
+    if (!chooseStreamResolution(desiredHDImgWidth,
+                                desiredHDImgHeight,
+                                &widthFrameHD,
                                 &heightFrameHD)) {
         syslog(LOG_ERR, "%s: Failed choosing HD resolution", __func__);
         goto end;
     }
-    syslog(LOG_INFO, "Creating VDO High resolution image provider and stream %d x %d", widthFrameHD,
+    syslog(LOG_INFO,
+           "Creating VDO High resolution image provider and stream %d x %d",
+           widthFrameHD,
            heightFrameHD);
     hdImageProvider = createImgProvider(widthFrameHD, heightFrameHD, 2, VDO_FORMAT_YUV);
     if (!hdImageProvider) {
@@ -593,8 +629,11 @@ int main(int argc, char** argv) {
         goto end;
     }
 
-    syslog(LOG_INFO, "Setting up larod connection with chip %s, model %s and label file %s",
-           chipString, modelFile, labelsFile);
+    syslog(LOG_INFO,
+           "Setting up larod connection with chip %s, model %s and label file %s",
+           chipString,
+           modelFile,
+           labelsFile);
     if (!setupLarod(chipString, larodModelFd, &conn, &model)) {
         goto end;
     }
@@ -605,7 +644,9 @@ int main(int argc, char** argv) {
     dev_pp  = larodGetDevice(conn, larodLibyuvPP, 0, &error);
     ppModel = larodLoadModel(conn, -1, dev_pp, LAROD_ACCESS_PRIVATE, "", ppMap, &error);
     if (!ppModel) {
-        syslog(LOG_ERR, "Unable to load preprocessing model with chip %s: %s", larodLibyuvPP,
+        syslog(LOG_ERR,
+               "Unable to load preprocessing model with chip %s: %s",
+               larodLibyuvPP,
                error->msg);
         goto end;
     } else {
@@ -618,7 +659,9 @@ int main(int argc, char** argv) {
     dev_pp_hd = larodGetDevice(conn, larodLibyuvPP, 0, &error);
     ppModelHD = larodLoadModel(conn, -1, dev_pp_hd, LAROD_ACCESS_PRIVATE, "", ppMapHD, &error);
     if (!ppModelHD) {
-        syslog(LOG_ERR, "Unable to load preprocessing model with chip %s: %s", larodLibyuvPP,
+        syslog(LOG_ERR,
+               "Unable to load preprocessing model with chip %s: %s",
+               larodLibyuvPP,
                error->msg);
         goto end;
     } else {
@@ -691,29 +734,40 @@ int main(int argc, char** argv) {
     if (!createAndMapTmpFile(PP_SD_INPUT_FILE_PATTERN, yuyvBufferSize, &ppInputAddr, &ppInputFd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(PP_SD_OUTPUT_FILE_PATTERN, rgbBufferSize, &ppOutputAddr,
+    if (!createAndMapTmpFile(PP_SD_OUTPUT_FILE_PATTERN,
+                             rgbBufferSize,
+                             &ppOutputAddr,
                              &ppOutputFd)) {
         goto end;
     }
     if (!createAndMapTmpFile(OBJECT_DETECTOR_INPUT_FILE_PATTERN,
-                             (inputWidth + padding) * inputHeight * CHANNELS, &larodInputAddr,
+                             (inputWidth + padding) * inputHeight * CHANNELS,
+                             &larodInputAddr,
                              &larodInputFd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(PP_HD_INPUT_FILE_PATTERN, widthFrameHD * heightFrameHD * CHANNELS / 2,
-                             &ppInputAddrHD, &ppInputFdHD)) {
+    if (!createAndMapTmpFile(PP_HD_INPUT_FILE_PATTERN,
+                             widthFrameHD * heightFrameHD * CHANNELS / 2,
+                             &ppInputAddrHD,
+                             &ppInputFdHD)) {
         goto end;
     }
-    if (!createAndMapTmpFile(PP_HD_OUTPUT_FILE_PATTERN, widthFrameHD * heightFrameHD * CHANNELS,
-                             &ppOutputAddrHD, &ppOutputFdHD)) {
+    if (!createAndMapTmpFile(PP_HD_OUTPUT_FILE_PATTERN,
+                             widthFrameHD * heightFrameHD * CHANNELS,
+                             &ppOutputAddrHD,
+                             &ppOutputFdHD)) {
         goto end;
     }
 
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT1_FILE_PATTERN, TENSOR1SIZE, &larodOutput1Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT1_FILE_PATTERN,
+                             TENSOR1SIZE,
+                             &larodOutput1Addr,
                              &larodOutput1Fd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT2_FILE_PATTERN, TENSOR2SIZE, &larodOutput2Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT2_FILE_PATTERN,
+                             TENSOR2SIZE,
+                             &larodOutput2Addr,
                              &larodOutput2Fd)) {
         goto end;
     }
@@ -758,22 +812,38 @@ int main(int argc, char** argv) {
 
     // Create job requests
     syslog(LOG_INFO, "Create job requests");
-    ppReq = larodCreateJobRequest(ppModel, ppInputTensors, ppNumInputs, ppOutputTensors,
-                                  ppNumOutputs, cropMap, &error);
+    ppReq = larodCreateJobRequest(ppModel,
+                                  ppInputTensors,
+                                  ppNumInputs,
+                                  ppOutputTensors,
+                                  ppNumOutputs,
+                                  cropMap,
+                                  &error);
     if (!ppReq) {
         syslog(LOG_ERR, "Failed creating preprocessing job request: %s", error->msg);
         goto end;
     }
-    ppReqHD = larodCreateJobRequest(ppModelHD, ppInputTensorsHD, ppNumInputsHD, ppOutputTensorsHD,
-                                    ppNumOutputsHD, NULL, &error);
+    ppReqHD = larodCreateJobRequest(ppModelHD,
+                                    ppInputTensorsHD,
+                                    ppNumInputsHD,
+                                    ppOutputTensorsHD,
+                                    ppNumOutputsHD,
+                                    NULL,
+                                    &error);
     if (!ppReqHD) {
-        syslog(LOG_ERR, "Failed creating high resolution preprocessing job request: %s",
+        syslog(LOG_ERR,
+               "Failed creating high resolution preprocessing job request: %s",
                error->msg);
         goto end;
     }
 
     // App supports only one input/output tensor.
-    infReq = larodCreateJobRequest(model, inputTensors, numInputs, outputTensors, numOutputs, NULL,
+    infReq = larodCreateJobRequest(model,
+                                   inputTensors,
+                                   numInputs,
+                                   outputTensors,
+                                   numOutputs,
+                                   NULL,
                                    &error);
     if (!infReq) {
         syslog(LOG_ERR, "Failed creating inference request: %s", error->msg);
@@ -828,7 +898,9 @@ int main(int argc, char** argv) {
 
         memcpy(ppInputAddr, nv12Data, yuyvBufferSize);
         if (!larodRunJob(conn, ppReq, &error)) {
-            syslog(LOG_ERR, "Unable to run job to preprocess model: %s (%d)", error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run job to preprocess model: %s (%d)",
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -837,7 +909,9 @@ int main(int argc, char** argv) {
 
         memcpy(ppInputAddrHD, nv12Data_hq, widthFrameHD * heightFrameHD * CHANNELS / 2);
         if (!larodRunJob(conn, ppReqHD, &error)) {
-            syslog(LOG_ERR, "Unable to run job to preprocess model: %s (%d)", error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run job to preprocess model: %s (%d)",
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -863,7 +937,10 @@ int main(int argc, char** argv) {
 
         gettimeofday(&startTs, NULL);
         if (!larodRunJob(conn, infReq, &error)) {
-            syslog(LOG_ERR, "Unable to run inference on model %s: %s (%d)", labelsFile, error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run inference on model %s: %s (%d)",
+                   labelsFile,
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -888,8 +965,18 @@ int main(int argc, char** argv) {
 
         gettimeofday(&startTs, NULL);
         // postprocessing the output of the network. This will fill the boxes array.
-        postProcessing(locations, classes, numberOfDetections, anchorFile, numberOfClasses,
-                       confidenceThreshold, iouThreshold, yScale, xScale, hScale, wScale, boxes);
+        postProcessing(locations,
+                       classes,
+                       numberOfDetections,
+                       anchorFile,
+                       numberOfClasses,
+                       confidenceThreshold,
+                       iouThreshold,
+                       yScale,
+                       xScale,
+                       hScale,
+                       wScale,
+                       boxes);
         gettimeofday(&endTs, NULL);
 
         elapsedMs = (unsigned int)(((endTs.tv_sec - startTs.tv_sec) * 1000) +
@@ -909,12 +996,24 @@ int main(int argc, char** argv) {
             unsigned int crop_h = (bottom - top) * heightFrameHD;
 
             if (boxes[i].score >= threshold / 100.0 && boxes[i].label != 0) {
-                syslog(LOG_INFO, "Object %d: Classes: %s - Scores: %f - Locations: [%f,%f,%f,%f]",
-                       i, labels[boxes[i].label - 1], boxes[i].score, top, left, bottom, right);
+                syslog(LOG_INFO,
+                       "Object %d: Classes: %s - Scores: %f - Locations: [%f,%f,%f,%f]",
+                       i,
+                       labels[boxes[i].label - 1],
+                       boxes[i].score,
+                       top,
+                       left,
+                       bottom,
+                       right);
 
-                unsigned char* crop_buffer =
-                    crop_interleaved(ppOutputAddrHD, widthFrameHD, heightFrameHD, CHANNELS, crop_x,
-                                     crop_y, crop_w, crop_h);
+                unsigned char* crop_buffer = crop_interleaved(ppOutputAddrHD,
+                                                              widthFrameHD,
+                                                              heightFrameHD,
+                                                              CHANNELS,
+                                                              crop_x,
+                                                              crop_y,
+                                                              crop_w,
+                                                              crop_h);
 
                 unsigned long jpeg_size    = 0;
                 unsigned char* jpeg_buffer = NULL;

--- a/object-detection-cv25/app/postprocessing.c
+++ b/object-detection-cv25/app/postprocessing.c
@@ -40,8 +40,12 @@ typedef struct {
  * [xmin,ymin,xmax,ymax]
  *
  */
-int loadDetectionStruct(const float* locations, float* classes, int num_of_detections,
-                        int num_of_classes, const char* anchor_file, detection* dets) {
+int loadDetectionStruct(const float* locations,
+                        float* classes,
+                        int num_of_detections,
+                        int num_of_classes,
+                        const char* anchor_file,
+                        detection* dets) {
     // Open anchor file
     FILE* fp;
     fp = fopen(anchor_file, "rb");
@@ -95,8 +99,13 @@ float min(float a, float b) {
 }
 
 // Apply anchors to detections to obtain boxes
-void applyAnchors(detection* dets, int num_of_detections, box* boxes, float y_scale, float x_scale,
-                  float h_scale, float w_scale) {
+void applyAnchors(detection* dets,
+                  int num_of_detections,
+                  box* boxes,
+                  float y_scale,
+                  float x_scale,
+                  float h_scale,
+                  float w_scale) {
     float prior_center_y, prior_center_x, prior_height, prior_width;
     float center_y, center_x, height, width;
     for (int i = 0; i < num_of_detections; i++) {
@@ -211,12 +220,25 @@ void copyBoxes(box* boxes, box* boxes2, int num_of_boxes) {
     }
 }
 
-int postProcessing(float* locations, float* classes, int num_of_detections, char* anchor_file,
-                   int num_of_classes, float score_threshold, float nms_threshold, float y_scale,
-                   float x_scale, float h_scale, float w_scale, box* boxes) {
+int postProcessing(float* locations,
+                   float* classes,
+                   int num_of_detections,
+                   char* anchor_file,
+                   int num_of_classes,
+                   float score_threshold,
+                   float nms_threshold,
+                   float y_scale,
+                   float x_scale,
+                   float h_scale,
+                   float w_scale,
+                   box* boxes) {
     // Load detections and anchors in struct array
     detection* dets = (detection*)malloc(num_of_detections * sizeof(detection));
-    if (loadDetectionStruct(locations, classes, num_of_detections, num_of_classes, anchor_file,
+    if (loadDetectionStruct(locations,
+                            classes,
+                            num_of_detections,
+                            num_of_classes,
+                            anchor_file,
                             dets) != 0) {
         printf("Error loading detection struct");
         free(dets);

--- a/object-detection-cv25/app/postprocessing.h
+++ b/object-detection-cv25/app/postprocessing.h
@@ -46,6 +46,15 @@ typedef struct {
  * @param w_scale scale factor for the width
  * @param boxes output array of boxes
  */
-int postProcessing(float* locations, float* classes, int num_of_detections, char* anchor_file,
-                   int num_of_classes, float score_threshold, float nms_threshold, float y_scale,
-                   float x_scale, float h_scale, float w_scale, box* boxes);
+int postProcessing(float* locations,
+                   float* classes,
+                   int num_of_detections,
+                   char* anchor_file,
+                   int num_of_classes,
+                   float score_threshold,
+                   float nms_threshold,
+                   float y_scale,
+                   float x_scale,
+                   float h_scale,
+                   float w_scale,
+                   box* boxes);

--- a/object-detection/app/argparse.c
+++ b/object-detection/app/argparse.c
@@ -28,7 +28,10 @@ static int parsePosInt(char* arg, unsigned long long* i, unsigned long long limi
 static int parseOpt(int key, char* arg, struct argp_state* state);
 
 const struct argp_option opts[] = {
-    {"chip", 'c', "CHIP", 0,
+    {"chip",
+     'c',
+     "CHIP",
+     0,
      "Chooses chip CHIP to run on, where CHIP is the enum type larodChip "
      "from the library. If not specified, the default chip for a new "
      "connection will be used.",

--- a/object-detection/app/imgprovider.c
+++ b/object-detection/app/imgprovider.c
@@ -91,8 +91,8 @@ static void releaseVdoBuffers(ImgProvider_t* provider);
  */
 static void* threadEntry(void* data);
 
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat format) {
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat format) {
     bool mtxInitialized  = false;
     bool condInitialized = false;
 
@@ -112,7 +112,9 @@ ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int nu
     mtxInitialized = true;
 
     if (pthread_cond_init(&provider->frameDeliverCond, NULL)) {
-        syslog(LOG_ERR, "%s: Unable to initialize condition variable: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Unable to initialize condition variable: %s",
+               __func__,
                strerror(errno));
         goto errorExit;
     }
@@ -183,7 +185,9 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
     for (size_t i = 0; i < NUM_VDO_BUFFERS; i++) {
         provider->vdoBuffers[i] = vdo_stream_buffer_alloc(vdoStream, NULL, &error);
         if (provider->vdoBuffers[i] == NULL) {
-            syslog(LOG_ERR, "%s: Failed creating VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed creating VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -193,13 +197,17 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
         // implementation.
         void* dummyPtr = vdo_buffer_get_data(provider->vdoBuffers[i]);
         if (!dummyPtr) {
-            syslog(LOG_ERR, "%s: Failed initializing buffer memmap: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed initializing buffer memmap: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
 
         if (!vdo_stream_buffer_enqueue(vdoStream, provider->vdoBuffers[i], &error)) {
-            syslog(LOG_ERR, "%s: Failed enqueue VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed enqueue VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -213,8 +221,10 @@ errorExit:
     return ret;
 }
 
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight) {
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight) {
     VdoResolutionSet* set = NULL;
     VdoChannel* channel   = NULL;
     GError* error         = NULL;
@@ -226,13 +236,17 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     // Retrieve channel resolutions
     channel = vdo_channel_get(VDO_CHANNEL, &error);
     if (!channel) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
     set = vdo_channel_get_resolutions(channel, NULL, &error);
     if (!set) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get_resolutions(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get_resolutions(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
@@ -259,8 +273,11 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     if (bestResolutionIdx >= 0) {
         *chosenWidth  = set->resolutions[bestResolutionIdx].width;
         *chosenHeight = set->resolutions[bestResolutionIdx].height;
-        syslog(LOG_INFO, "%s: We select stream w/h=%u x %u based on VDO channel info.\n", __func__,
-               *chosenWidth, *chosenHeight);
+        syslog(LOG_INFO,
+               "%s: We select stream w/h=%u x %u based on VDO channel info.\n",
+               __func__,
+               *chosenWidth,
+               *chosenHeight);
     } else {
         syslog(LOG_WARNING,
                "%s: VDO channel info contains no reslution info. Fallback "
@@ -300,7 +317,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     VdoStream* vdoStream = vdo_stream_new(vdoMap, NULL, &error);
     if (!vdoStream) {
-        syslog(LOG_ERR, "%s: Failed creating vdo stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed creating vdo stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -312,7 +331,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     // Start the actual VDO streaming.
     if (!vdo_stream_start(vdoStream, &error)) {
-        syslog(LOG_ERR, "%s: Failed starting stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed starting stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -383,7 +404,9 @@ static void* threadEntry(void* data) {
 
         if (!newBuffer) {
             // Fail but we continue anyway hoping for the best.
-            syslog(LOG_WARNING, "%s: Failed fetching frame from vdo: %s", __func__,
+            syslog(LOG_WARNING,
+                   "%s: Failed fetching frame from vdo: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             g_clear_error(&error);
             continue;
@@ -410,7 +433,9 @@ static void* threadEntry(void* data) {
         if (oldBuffer) {
             if (!vdo_stream_buffer_enqueue(provider->vdoStream, oldBuffer, &error)) {
                 // Fail but we continue anyway hoping for the best.
-                syslog(LOG_WARNING, "%s: Failed enqueueing buffer to vdo: %s", __func__,
+                syslog(LOG_WARNING,
+                       "%s: Failed enqueueing buffer to vdo: %s",
+                       __func__,
                        (error != NULL) ? error->message : "N/A");
                 g_clear_error(&error);
             }
@@ -423,7 +448,9 @@ static void* threadEntry(void* data) {
 
 bool startFrameFetch(ImgProvider_t* provider) {
     if (pthread_create(&provider->fetcherThread, NULL, threadEntry, provider)) {
-        syslog(LOG_ERR, "%s: Failed to start thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to start thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }
@@ -435,7 +462,9 @@ bool stopFrameFetch(ImgProvider_t* provider) {
     provider->shutDown = true;
 
     if (pthread_join(provider->fetcherThread, NULL)) {
-        syslog(LOG_ERR, "%s: Failed to join thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to join thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }

--- a/object-detection/app/imgprovider.h
+++ b/object-detection/app/imgprovider.h
@@ -70,8 +70,10 @@ typedef struct ImgProvider {
  * param chosenHeight Selected image height.
  * return False if any errors occur, otherwise true.
  */
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight);
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight);
 
 /**
  * brief Initializes and starts an ImgProvider.
@@ -86,8 +88,8 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
  * param vdoFormat Image format to be output by stream.
  * return Pointer to new ImgProvider, or NULL if failed.
  */
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat vdoFormat);
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat vdoFormat);
 
 /**
  * brief Release VDO buffers and deallocate provider.

--- a/object-detection/app/imgutils.c
+++ b/object-detection/app/imgutils.c
@@ -31,8 +31,10 @@
  * @param jpeg_size The output size of the jpeg
  * @param jpeg_buffer The output buffer of the jpeg
  */
-void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jpeg_conf,
-                    unsigned long* jpeg_size, unsigned char** jpeg_buffer) {
+void buffer_to_jpeg(unsigned char* image_buffer,
+                    struct jpeg_compress_struct* jpeg_conf,
+                    unsigned long* jpeg_size,
+                    unsigned char** jpeg_buffer) {
     struct jpeg_error_mgr jerr;
     JSAMPROW row_pointer[1];
 
@@ -60,7 +62,10 @@ void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jp
  * @param quality The desired jpeg quality (0-100)
  * @param jpeg_conf The jpeg configuration struct to modify
  */
-void set_jpeg_configuration(int width, int height, int channels, int quality,
+void set_jpeg_configuration(int width,
+                            int height,
+                            int channels,
+                            int quality,
                             struct jpeg_compress_struct* jpeg_conf) {
     // Only supports RGB and grayscale
     jpeg_create_compress(jpeg_conf);
@@ -111,8 +116,14 @@ void jpeg_to_file(char* file_name, unsigned char* buffer, unsigned long buffer_s
  * @param crop_w The width of the desired crop in pixels
  * @param crop_h The height of the desired crop in pixels
  */
-unsigned char* crop_interleaved(unsigned char* image_buffer, int image_w, int image_h, int channels,
-                                int crop_x, int crop_y, int crop_w, int crop_h) {
+unsigned char* crop_interleaved(unsigned char* image_buffer,
+                                int image_w,
+                                int image_h,
+                                int channels,
+                                int crop_x,
+                                int crop_y,
+                                int crop_w,
+                                int crop_h) {
     // This function crops out a section of an image that is located at
     // (x, y, x + w, x + h).
     // The input buffer channel layout is assumed to be interleaved

--- a/object-detection/app/imgutils.h
+++ b/object-detection/app/imgutils.h
@@ -27,8 +27,10 @@
  * @param jpeg_size The output size of the jpeg
  * @param jpeg_buffer The output buffer of the jpeg
  */
-void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jpeg_conf,
-                    unsigned long* jpeg_size, unsigned char** jpeg_buffer);
+void buffer_to_jpeg(unsigned char* image_buffer,
+                    struct jpeg_compress_struct* jpeg_conf,
+                    unsigned long* jpeg_size,
+                    unsigned char** jpeg_buffer);
 
 /**
  * @brief Inserts common values into a jpeg configuration struct
@@ -39,7 +41,10 @@ void buffer_to_jpeg(unsigned char* image_buffer, struct jpeg_compress_struct* jp
  * @param quality The desired jpeg quality (0-100)
  * @param jpeg_conf The jpeg configuration struct to modify
  */
-void set_jpeg_configuration(int width, int height, int channels, int quality,
+void set_jpeg_configuration(int width,
+                            int height,
+                            int channels,
+                            int quality,
                             struct jpeg_compress_struct* jpeg_conf);
 
 /**
@@ -64,8 +69,14 @@ void jpeg_to_file(char* file_name, unsigned char* buffer, unsigned long buffer_s
  * @param crop_w The width of the desired crop in pixels
  * @param crop_h The height of the desired crop in pixels
  */
-unsigned char* crop_interleaved(unsigned char* image_buffer, int image_w, int image_h, int channels,
-                                int crop_x, int crop_y, int crop_w, int crop_h);
+unsigned char* crop_interleaved(unsigned char* image_buffer,
+                                int image_w,
+                                int image_h,
+                                int channels,
+                                int crop_x,
+                                int crop_y,
+                                int crop_w,
+                                int crop_h);
 
 /**
  * @brief An example of how to use the supplied utility functions

--- a/object-detection/app/object_detection.c
+++ b/object-detection/app/object_detection.c
@@ -83,7 +83,9 @@ void freeLabels(char** labelsArray, char* labelFileBuffer) {
  * @param numLabelsPtr Pointer to number which will store number of labels read.
  * @return False if any errors occur, otherwise true.
  */
-static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* labelsPath,
+static bool parseLabels(char*** labelsPtr,
+                        char** labelFileBuffer,
+                        const char* labelsPath,
                         size_t* numLabelsPtr) {
     // We cut off every row at 60 characters.
     const size_t LINE_MAX_LEN = 60;
@@ -93,7 +95,10 @@ static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* l
 
     struct stat fileStats = {0};
     if (stat(labelsPath, &fileStats) < 0) {
-        syslog(LOG_ERR, "%s: Unable to get stats for label file %s: %s", __func__, labelsPath,
+        syslog(LOG_ERR,
+               "%s: Unable to get stats for label file %s: %s",
+               __func__,
+               labelsPath,
                strerror(errno));
         return false;
     }
@@ -110,7 +115,10 @@ static bool parseLabels(char*** labelsPtr, char** labelFileBuffer, const char* l
 
     int labelsFd = open(labelsPath, O_RDONLY);
     if (labelsFd < 0) {
-        syslog(LOG_ERR, "%s: Could not open labels file %s: %s", __func__, labelsPath,
+        syslog(LOG_ERR,
+               "%s: Could not open labels file %s: %s",
+               __func__,
+               labelsPath,
                strerror(errno));
         return false;
     }
@@ -244,7 +252,10 @@ void sigintHandler(int sig) {
  * @return Positive errno style return code (zero means success).
  */
 static bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAddr, int* convFd) {
-    syslog(LOG_INFO, "%s: Setting up a temp fd with pattern %s and size %zu", __func__, fileName,
+    syslog(LOG_INFO,
+           "%s: Setting up a temp fd with pattern %s and size %zu",
+           __func__,
+           fileName,
            fileSize);
 
     int fd = mkstemp(fileName);
@@ -255,14 +266,20 @@ static bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAd
 
     // Allocate enough space in for the fd.
     if (ftruncate(fd, (off_t)fileSize) < 0) {
-        syslog(LOG_ERR, "%s: Unable to truncate temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to truncate temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }
 
     // Remove since we don't actually care about writing to the file system.
     if (unlink(fileName)) {
-        syslog(LOG_ERR, "%s: Unable to unlink from temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to unlink from temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }
@@ -302,7 +319,9 @@ error:
  * @param model Pointer to a larodModel to be obtained.
  * @return false if error has occurred, otherwise true.
  */
-static bool setupLarod(const char* chipString, const int larodModelFd, larodConnection** larodConn,
+static bool setupLarod(const char* chipString,
+                       const int larodModelFd,
+                       larodConnection** larodConn,
                        larodModel** model) {
     larodError* error       = NULL;
     larodConnection* conn   = NULL;
@@ -325,8 +344,13 @@ static bool setupLarod(const char* chipString, const int larodModelFd, larodConn
         ;
     }
     const larodDevice* dev = larodGetDevice(conn, chipString, 0, &error);
-    loadedModel = larodLoadModel(conn, larodModelFd, dev, LAROD_ACCESS_PRIVATE, "object_detection",
-                                 NULL, &error);
+    loadedModel            = larodLoadModel(conn,
+                                 larodModelFd,
+                                 dev,
+                                 LAROD_ACCESS_PRIVATE,
+                                 "object_detection",
+                                 NULL,
+                                 &error);
     if (!loadedModel) {
         syslog(LOG_ERR, "%s: Unable to load model: %s", __func__, error->msg);
         goto error;
@@ -458,7 +482,9 @@ int main(int argc, char** argv) {
         goto end;
     }
 
-    syslog(LOG_INFO, "Creating VDO image provider and creating stream %d x %d", streamWidth,
+    syslog(LOG_INFO,
+           "Creating VDO image provider and creating stream %d x %d",
+           streamWidth,
            streamHeight);
     sdImageProvider = createImgProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
     if (!sdImageProvider) {
@@ -468,12 +494,16 @@ int main(int argc, char** argv) {
     syslog(LOG_INFO, "Find the best resolution to save the high resolution image");
     unsigned int widthFrameHD;
     unsigned int heightFrameHD;
-    if (!chooseStreamResolution(desiredHDImgWidth, desiredHDImgHeight, &widthFrameHD,
+    if (!chooseStreamResolution(desiredHDImgWidth,
+                                desiredHDImgHeight,
+                                &widthFrameHD,
                                 &heightFrameHD)) {
         syslog(LOG_ERR, "%s: Failed choosing HD resolution", __func__);
         goto end;
     }
-    syslog(LOG_INFO, "Creating VDO High resolution image provider and stream %d x %d", widthFrameHD,
+    syslog(LOG_INFO,
+           "Creating VDO High resolution image provider and stream %d x %d",
+           widthFrameHD,
            heightFrameHD);
     hdImageProvider = createImgProvider(widthFrameHD, heightFrameHD, 2, VDO_FORMAT_YUV);
     if (!hdImageProvider) {
@@ -562,8 +592,11 @@ int main(int argc, char** argv) {
         goto end;
     }
 
-    syslog(LOG_INFO, "Setting up larod connection with chip %s, model %s and label file %s",
-           chipString, modelFile, labelsFile);
+    syslog(LOG_INFO,
+           "Setting up larod connection with chip %s, model %s and label file %s",
+           chipString,
+           modelFile,
+           labelsFile);
     if (!setupLarod(chipString, larodModelFd, &conn, &model)) {
         goto end;
     }
@@ -574,7 +607,9 @@ int main(int argc, char** argv) {
     dev_pp  = larodGetDevice(conn, larodLibyuvPP, 0, &error);
     ppModel = larodLoadModel(conn, -1, dev_pp, LAROD_ACCESS_PRIVATE, "", ppMap, &error);
     if (!ppModel) {
-        syslog(LOG_ERR, "Unable to load preprocessing model with chip %s: %s", larodLibyuvPP,
+        syslog(LOG_ERR,
+               "Unable to load preprocessing model with chip %s: %s",
+               larodLibyuvPP,
                error->msg);
         goto end;
     } else {
@@ -587,7 +622,9 @@ int main(int argc, char** argv) {
     dev_pp_hd = larodGetDevice(conn, larodLibyuvPP, 0, &error);
     ppModelHD = larodLoadModel(conn, -1, dev_pp_hd, LAROD_ACCESS_PRIVATE, "", ppMapHD, &error);
     if (!ppModelHD) {
-        syslog(LOG_ERR, "Unable to load preprocessing model with chip %s: %s", larodLibyuvPP,
+        syslog(LOG_ERR,
+               "Unable to load preprocessing model with chip %s: %s",
+               larodLibyuvPP,
                error->msg);
         goto end;
     } else {
@@ -661,33 +698,47 @@ int main(int argc, char** argv) {
         goto end;
     }
     if (!createAndMapTmpFile(OBJECT_DETECTOR_INPUT_FILE_PATTERN,
-                             inputWidth * inputHeight * CHANNELS, &larodInputAddr, &larodInputFd)) {
+                             inputWidth * inputHeight * CHANNELS,
+                             &larodInputAddr,
+                             &larodInputFd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(PP_HD_INPUT_FILE_PATTERN, widthFrameHD * heightFrameHD * CHANNELS / 2,
-                             &ppInputAddrHD, &ppInputFdHD)) {
+    if (!createAndMapTmpFile(PP_HD_INPUT_FILE_PATTERN,
+                             widthFrameHD * heightFrameHD * CHANNELS / 2,
+                             &ppInputAddrHD,
+                             &ppInputFdHD)) {
         goto end;
     }
-    if (!createAndMapTmpFile(PP_HD_OUTPUT_FILE_PATTERN, widthFrameHD * heightFrameHD * CHANNELS,
-                             &ppOutputAddrHD, &ppOutputFdHD)) {
+    if (!createAndMapTmpFile(PP_HD_OUTPUT_FILE_PATTERN,
+                             widthFrameHD * heightFrameHD * CHANNELS,
+                             &ppOutputAddrHD,
+                             &ppOutputFdHD)) {
         goto end;
     }
 
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT1_FILE_PATTERN, TENSOR1SIZE, &larodOutput1Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT1_FILE_PATTERN,
+                             TENSOR1SIZE,
+                             &larodOutput1Addr,
                              &larodOutput1Fd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT2_FILE_PATTERN, TENSOR2SIZE, &larodOutput2Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT2_FILE_PATTERN,
+                             TENSOR2SIZE,
+                             &larodOutput2Addr,
                              &larodOutput2Fd)) {
         goto end;
     }
 
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT3_FILE_PATTERN, TENSOR3SIZE, &larodOutput3Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT3_FILE_PATTERN,
+                             TENSOR3SIZE,
+                             &larodOutput3Addr,
                              &larodOutput3Fd)) {
         goto end;
     }
 
-    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT4_FILE_PATTERN, TENSOR4SIZE, &larodOutput4Addr,
+    if (!createAndMapTmpFile(OBJECT_DETECTOR_OUT4_FILE_PATTERN,
+                             TENSOR4SIZE,
+                             &larodOutput4Addr,
                              &larodOutput4Fd)) {
         goto end;
     }
@@ -742,22 +793,38 @@ int main(int argc, char** argv) {
 
     // Create job requests
     syslog(LOG_INFO, "Create job requests");
-    ppReq = larodCreateJobRequest(ppModel, ppInputTensors, ppNumInputs, ppOutputTensors,
-                                  ppNumOutputs, cropMap, &error);
+    ppReq = larodCreateJobRequest(ppModel,
+                                  ppInputTensors,
+                                  ppNumInputs,
+                                  ppOutputTensors,
+                                  ppNumOutputs,
+                                  cropMap,
+                                  &error);
     if (!ppReq) {
         syslog(LOG_ERR, "Failed creating preprocessing job request: %s", error->msg);
         goto end;
     }
-    ppReqHD = larodCreateJobRequest(ppModelHD, ppInputTensorsHD, ppNumInputsHD, ppOutputTensorsHD,
-                                    ppNumOutputsHD, NULL, &error);
+    ppReqHD = larodCreateJobRequest(ppModelHD,
+                                    ppInputTensorsHD,
+                                    ppNumInputsHD,
+                                    ppOutputTensorsHD,
+                                    ppNumOutputsHD,
+                                    NULL,
+                                    &error);
     if (!ppReqHD) {
-        syslog(LOG_ERR, "Failed creating high resolution preprocessing job request: %s",
+        syslog(LOG_ERR,
+               "Failed creating high resolution preprocessing job request: %s",
                error->msg);
         goto end;
     }
 
     // App supports only one input/output tensor.
-    infReq = larodCreateJobRequest(model, inputTensors, numInputs, outputTensors, numOutputs, NULL,
+    infReq = larodCreateJobRequest(model,
+                                   inputTensors,
+                                   numInputs,
+                                   outputTensors,
+                                   numOutputs,
+                                   NULL,
                                    &error);
     if (!infReq) {
         syslog(LOG_ERR, "Failed creating inference request: %s", error->msg);
@@ -809,13 +876,17 @@ int main(int argc, char** argv) {
 
         memcpy(ppInputAddr, nv12Data, yuyvBufferSize);
         if (!larodRunJob(conn, ppReq, &error)) {
-            syslog(LOG_ERR, "Unable to run job to preprocess model: %s (%d)", error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run job to preprocess model: %s (%d)",
+                   error->msg,
                    error->code);
             goto end;
         }
         memcpy(ppInputAddrHD, nv12Data_hq, widthFrameHD * heightFrameHD * CHANNELS / 2);
         if (!larodRunJob(conn, ppReqHD, &error)) {
-            syslog(LOG_ERR, "Unable to run job to preprocess model: %s (%d)", error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run job to preprocess model: %s (%d)",
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -850,7 +921,10 @@ int main(int argc, char** argv) {
 
         gettimeofday(&startTs, NULL);
         if (!larodRunJob(conn, infReq, &error)) {
-            syslog(LOG_ERR, "Unable to run inference on model %s: %s (%d)", labelsFile, error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run inference on model %s: %s (%d)",
+                   labelsFile,
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -884,12 +958,24 @@ int main(int argc, char** argv) {
             unsigned int crop_h = (bottom - top) * heightFrameHD;
 
             if (scores[i] >= threshold / 100.0) {
-                syslog(LOG_INFO, "Object %d: Classes: %s - Scores: %f - Locations: [%f,%f,%f,%f]",
-                       i, labels[(int)classes[i]], scores[i], top, left, bottom, right);
+                syslog(LOG_INFO,
+                       "Object %d: Classes: %s - Scores: %f - Locations: [%f,%f,%f,%f]",
+                       i,
+                       labels[(int)classes[i]],
+                       scores[i],
+                       top,
+                       left,
+                       bottom,
+                       right);
 
-                unsigned char* crop_buffer =
-                    crop_interleaved(ppOutputAddrHD, widthFrameHD, heightFrameHD, CHANNELS, crop_x,
-                                     crop_y, crop_w, crop_h);
+                unsigned char* crop_buffer = crop_interleaved(ppOutputAddrHD,
+                                                              widthFrameHD,
+                                                              heightFrameHD,
+                                                              CHANNELS,
+                                                              crop_x,
+                                                              crop_y,
+                                                              crop_w,
+                                                              crop_h);
 
                 unsigned long jpeg_size    = 0;
                 unsigned char* jpeg_buffer = NULL;

--- a/using-opencv/app/example.cpp
+++ b/using-opencv/app/example.cpp
@@ -41,7 +41,9 @@ int main(int argc, char* argv[]) {
         exit(1);
     }
 
-    syslog(LOG_INFO, "Creating VDO image provider and creating stream %d x %d", streamWidth,
+    syslog(LOG_INFO,
+           "Creating VDO image provider and creating stream %d x %d",
+           streamWidth,
            streamHeight);
     provider = createImgProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
     if (!provider) {

--- a/using-opencv/app/imgprovider.h
+++ b/using-opencv/app/imgprovider.h
@@ -73,8 +73,10 @@ typedef struct ImgProvider {
  * param chosenHeight Selected image height.
  * return False if any errors occur, otherwise true.
  */
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight);
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight);
 
 /**
  * brief Initializes and starts an ImgProvider.
@@ -89,8 +91,8 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
  * param vdoFormat Image format to be output by stream.
  * return Pointer to new ImgProvider, or NULL if failed.
  */
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat vdoFormat);
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat vdoFormat);
 
 /**
  * brief Release VDO buffers and deallocate provider.

--- a/utility-libraries/openssl_curl_example/app/openssl_curl_example.c
+++ b/utility-libraries/openssl_curl_example/app/openssl_curl_example.c
@@ -121,15 +121,19 @@ int main(void) {
     CURLcode rv;
     struct File fetch_file = {
         // Path to the file which will store the fetched web content
-        "/usr/local/packages/openssl_curl_example/localdata/www.example.com.txt", NULL};
+        "/usr/local/packages/openssl_curl_example/localdata/www.example.com.txt",
+        NULL};
 
     // Start logging
     openlog(NULL, LOG_PID, LOG_USER);
 
     // Log the curl and openssl library versions used in the code
     curl_version_info_data* ver = curl_version_info(CURLVERSION_NOW);
-    syslog(LOG_INFO, "ACAP application curl version: %u.%u.%u\n", (ver->version_num >> 16) & 0xff,
-           (ver->version_num >> 8) & 0xff, ver->version_num & 0xff);
+    syslog(LOG_INFO,
+           "ACAP application curl version: %u.%u.%u\n",
+           (ver->version_num >> 16) & 0xff,
+           (ver->version_num >> 8) & 0xff,
+           ver->version_num & 0xff);
     syslog(LOG_INFO, "ACAP application openssl version: %s", OpenSSL_version(OPENSSL_VERSION));
 
     // This function sets up the program environment that libcurl needs

--- a/vdo-larod/app/imgprovider.c
+++ b/vdo-larod/app/imgprovider.c
@@ -91,8 +91,8 @@ static void releaseVdoBuffers(ImgProvider_t* provider);
  */
 static void* threadEntry(void* data);
 
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat format) {
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat format) {
     bool mtxInitialized  = false;
     bool condInitialized = false;
 
@@ -112,7 +112,9 @@ ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int nu
     mtxInitialized = true;
 
     if (pthread_cond_init(&provider->frameDeliverCond, NULL)) {
-        syslog(LOG_ERR, "%s: Unable to initialize condition variable: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Unable to initialize condition variable: %s",
+               __func__,
                strerror(errno));
         goto errorExit;
     }
@@ -183,7 +185,9 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
     for (size_t i = 0; i < NUM_VDO_BUFFERS; i++) {
         provider->vdoBuffers[i] = vdo_stream_buffer_alloc(vdoStream, NULL, &error);
         if (provider->vdoBuffers[i] == NULL) {
-            syslog(LOG_ERR, "%s: Failed creating VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed creating VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -193,13 +197,17 @@ bool allocateVdoBuffers(ImgProvider_t* provider, VdoStream* vdoStream) {
         // implementation.
         void* dummyPtr = vdo_buffer_get_data(provider->vdoBuffers[i]);
         if (!dummyPtr) {
-            syslog(LOG_ERR, "%s: Failed initializing buffer memmap: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed initializing buffer memmap: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
 
         if (!vdo_stream_buffer_enqueue(vdoStream, provider->vdoBuffers[i], &error)) {
-            syslog(LOG_ERR, "%s: Failed enqueue VDO buffer: %s", __func__,
+            syslog(LOG_ERR,
+                   "%s: Failed enqueue VDO buffer: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             goto errorExit;
         }
@@ -213,8 +221,10 @@ errorExit:
     return ret;
 }
 
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight) {
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight) {
     VdoResolutionSet* set = NULL;
     VdoChannel* channel   = NULL;
     GError* error         = NULL;
@@ -226,13 +236,17 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     // Retrieve channel resolutions
     channel = vdo_channel_get(VDO_CHANNEL, &error);
     if (!channel) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
     set = vdo_channel_get_resolutions(channel, NULL, &error);
     if (!set) {
-        syslog(LOG_ERR, "%s: Failed vdo_channel_get_resolutions(): %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed vdo_channel_get_resolutions(): %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto end;
     }
@@ -259,8 +273,11 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
     if (bestResolutionIdx >= 0) {
         *chosenWidth  = set->resolutions[bestResolutionIdx].width;
         *chosenHeight = set->resolutions[bestResolutionIdx].height;
-        syslog(LOG_INFO, "%s: We select stream w/h=%u x %u based on VDO channel info.\n", __func__,
-               *chosenWidth, *chosenHeight);
+        syslog(LOG_INFO,
+               "%s: We select stream w/h=%u x %u based on VDO channel info.\n",
+               __func__,
+               *chosenWidth,
+               *chosenHeight);
     } else {
         syslog(LOG_WARNING,
                "%s: VDO channel info contains no reslution info. Fallback "
@@ -300,7 +317,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     VdoStream* vdoStream = vdo_stream_new(vdoMap, NULL, &error);
     if (!vdoStream) {
-        syslog(LOG_ERR, "%s: Failed creating vdo stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed creating vdo stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -312,7 +331,9 @@ bool createStream(ImgProvider_t* provider, unsigned int w, unsigned int h) {
 
     // Start the actual VDO streaming.
     if (!vdo_stream_start(vdoStream, &error)) {
-        syslog(LOG_ERR, "%s: Failed starting stream: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed starting stream: %s",
+               __func__,
                (error != NULL) ? error->message : "N/A");
         goto errorExit;
     }
@@ -383,7 +404,9 @@ static void* threadEntry(void* data) {
 
         if (!newBuffer) {
             // Fail but we continue anyway hoping for the best.
-            syslog(LOG_WARNING, "%s: Failed fetching frame from vdo: %s", __func__,
+            syslog(LOG_WARNING,
+                   "%s: Failed fetching frame from vdo: %s",
+                   __func__,
                    (error != NULL) ? error->message : "N/A");
             g_clear_error(&error);
             continue;
@@ -410,7 +433,9 @@ static void* threadEntry(void* data) {
         if (oldBuffer) {
             if (!vdo_stream_buffer_enqueue(provider->vdoStream, oldBuffer, &error)) {
                 // Fail but we continue anyway hoping for the best.
-                syslog(LOG_WARNING, "%s: Failed enqueueing buffer to vdo: %s", __func__,
+                syslog(LOG_WARNING,
+                       "%s: Failed enqueueing buffer to vdo: %s",
+                       __func__,
                        (error != NULL) ? error->message : "N/A");
                 g_clear_error(&error);
             }
@@ -424,7 +449,9 @@ static void* threadEntry(void* data) {
 
 bool startFrameFetch(ImgProvider_t* provider) {
     if (pthread_create(&provider->fetcherThread, NULL, threadEntry, provider)) {
-        syslog(LOG_ERR, "%s: Failed to start thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to start thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }
@@ -436,7 +463,9 @@ bool stopFrameFetch(ImgProvider_t* provider) {
     provider->shutDown = true;
 
     if (pthread_join(provider->fetcherThread, NULL)) {
-        syslog(LOG_ERR, "%s: Failed to join thread fetching frames from vdo: %s", __func__,
+        syslog(LOG_ERR,
+               "%s: Failed to join thread fetching frames from vdo: %s",
+               __func__,
                strerror(errno));
         return false;
     }

--- a/vdo-larod/app/imgprovider.h
+++ b/vdo-larod/app/imgprovider.h
@@ -70,8 +70,10 @@ typedef struct ImgProvider {
  * param chosenHeight Selected image height.
  * return False if any errors occur, otherwise true.
  */
-bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
-                            unsigned int* chosenWidth, unsigned int* chosenHeight);
+bool chooseStreamResolution(unsigned int reqWidth,
+                            unsigned int reqHeight,
+                            unsigned int* chosenWidth,
+                            unsigned int* chosenHeight);
 
 /**
  * brief Initializes and starts an ImgProvider.
@@ -86,8 +88,8 @@ bool chooseStreamResolution(unsigned int reqWidth, unsigned int reqHeight,
  * param vdoFormat Image format to be output by stream.
  * return Pointer to new ImgProvider, or NULL if failed.
  */
-ImgProvider_t* createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames,
-                                 VdoFormat vdoFormat);
+ImgProvider_t*
+createImgProvider(unsigned int w, unsigned int h, unsigned int numFrames, VdoFormat vdoFormat);
 
 /**
  * brief Release VDO buffers and deallocate provider.

--- a/vdo-larod/app/utility-functions.c
+++ b/vdo-larod/app/utility-functions.c
@@ -39,7 +39,10 @@ void saveRgbImageAsPpm(const uint8_t* rgbData, int width, int height, const char
 }
 
 bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAddr, int* convFd) {
-    syslog(LOG_INFO, "%s: Setting up a temp fd with pattern %s and size %zu", __func__, fileName,
+    syslog(LOG_INFO,
+           "%s: Setting up a temp fd with pattern %s and size %zu",
+           __func__,
+           fileName,
            fileSize);
 
     int fd = mkstemp(fileName);
@@ -50,14 +53,20 @@ bool createAndMapTmpFile(char* fileName, size_t fileSize, void** mappedAddr, int
 
     // Allocate enough space in for the fd.
     if (ftruncate(fd, (off_t)fileSize) < 0) {
-        syslog(LOG_ERR, "%s: Unable to truncate temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to truncate temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }
 
     // Remove since we don't actually care about writing to the file system.
     if (unlink(fileName)) {
-        syslog(LOG_ERR, "%s: Unable to unlink from temp file %s: %s", __func__, fileName,
+        syslog(LOG_ERR,
+               "%s: Unable to unlink from temp file %s: %s",
+               __func__,
+               fileName,
                strerror(errno));
         goto error;
     }

--- a/vdo-larod/app/vdo_larod.c
+++ b/vdo-larod/app/vdo_larod.c
@@ -72,7 +72,9 @@ static void sigintHandler(int sig) {
  * param model Pointer to a larodModel to be obtained.
  * return False if error has occurred, otherwise true.
  */
-static bool setupLarod(const char* chipString, const int larodModelFd, larodConnection** larodConn,
+static bool setupLarod(const char* chipString,
+                       const int larodModelFd,
+                       larodConnection** larodConn,
                        larodModel** model) {
     larodError* error       = NULL;
     larodConnection* conn   = NULL;
@@ -95,8 +97,13 @@ static bool setupLarod(const char* chipString, const int larodModelFd, larodConn
         ;
     }
     const larodDevice* dev = larodGetDevice(conn, chipString, 0, &error);
-    loadedModel            = larodLoadModel(conn, larodModelFd, dev, LAROD_ACCESS_PRIVATE,
-                                 "Vdo Example App Model", NULL, &error);
+    loadedModel            = larodLoadModel(conn,
+                                 larodModelFd,
+                                 dev,
+                                 LAROD_ACCESS_PRIVATE,
+                                 "Vdo Example App Model",
+                                 NULL,
+                                 &error);
     if (!loadedModel) {
         syslog(LOG_ERR, "%s: Unable to load model: %s", __func__, error->msg);
         goto error;
@@ -190,7 +197,9 @@ int main(int argc, char** argv) {
         goto end;
     }
 
-    syslog(LOG_INFO, "Creating VDO image provider and creating stream %d x %d", streamWidth,
+    syslog(LOG_INFO,
+           "Creating VDO image provider and creating stream %d x %d",
+           streamWidth,
            streamHeight);
     provider = createImgProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
     if (!provider) {
@@ -264,7 +273,9 @@ int main(int argc, char** argv) {
         goto end;
     }
 
-    syslog(LOG_INFO, "Setting up larod connection with chip %s and model file %s", chipString,
+    syslog(LOG_INFO,
+           "Setting up larod connection with chip %s and model file %s",
+           chipString,
            modelFile);
     if (!setupLarod(chipString, larodModelFd, &conn, &model)) {
         goto end;
@@ -276,7 +287,9 @@ int main(int argc, char** argv) {
     dev_pp  = larodGetDevice(conn, larodLibyuvPP, 0, &error);
     ppModel = larodLoadModel(conn, -1, dev_pp, LAROD_ACCESS_PRIVATE, "", ppMap, &error);
     if (!ppModel) {
-        syslog(LOG_ERR, "Unable to load preprocessing model with chip %s: %s", larodLibyuvPP,
+        syslog(LOG_ERR,
+               "Unable to load preprocessing model with chip %s: %s",
+               larodLibyuvPP,
                error->msg);
         goto end;
     } else {
@@ -347,8 +360,10 @@ int main(int argc, char** argv) {
     if (!createAndMapTmpFile(CONV_PP_FILE_PATTERN, yuyvBufferSize, &ppInputAddr, &ppInputFd)) {
         goto end;
     }
-    if (!createAndMapTmpFile(CONV_INP_FILE_PATTERN, inputWidth * inputHeight * CHANNELS,
-                             &larodInputAddr, &larodInputFd)) {
+    if (!createAndMapTmpFile(CONV_INP_FILE_PATTERN,
+                             inputWidth * inputHeight * CHANNELS,
+                             &larodInputAddr,
+                             &larodInputFd)) {
         goto end;
     }
     if (!createAndMapTmpFile(CONV_OUT1_FILE_PATTERN, 4, &larodOutput1Addr, &larodOutput1Fd)) {
@@ -384,8 +399,13 @@ int main(int argc, char** argv) {
 
     // Create job requests
     syslog(LOG_INFO, "Create job requests");
-    ppReq = larodCreateJobRequest(ppModel, ppInputTensors, ppNumInputs, ppOutputTensors,
-                                  ppNumOutputs, cropMap, &error);
+    ppReq = larodCreateJobRequest(ppModel,
+                                  ppInputTensors,
+                                  ppNumInputs,
+                                  ppOutputTensors,
+                                  ppNumOutputs,
+                                  cropMap,
+                                  &error);
     if (!ppReq) {
         syslog(LOG_ERR, "Failed creating preprocessing job request: %s", error->msg);
         goto end;
@@ -420,7 +440,9 @@ int main(int argc, char** argv) {
         gettimeofday(&startTs, NULL);
         memcpy(ppInputAddr, nv12Data, yuyvBufferSize);
         if (!larodRunJob(conn, ppReq, &error)) {
-            syslog(LOG_ERR, "Unable to run job to preprocess model: %s (%d)", error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run job to preprocess model: %s (%d)",
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -448,7 +470,10 @@ int main(int argc, char** argv) {
 
         gettimeofday(&startTs, NULL);
         if (!larodRunJob(conn, infReq, &error)) {
-            syslog(LOG_ERR, "Unable to run inference on model %s: %s (%d)", modelFile, error->msg,
+            syslog(LOG_ERR,
+                   "Unable to run inference on model %s: %s (%d)",
+                   modelFile,
+                   error->msg,
                    error->code);
             goto end;
         }
@@ -462,15 +487,19 @@ int main(int argc, char** argv) {
             uint8_t* person_pred = (uint8_t*)larodOutput1Addr;
             uint8_t* car_pred    = (uint8_t*)larodOutput2Addr;
 
-            syslog(LOG_INFO, "Person detected: %.2f%% - Car detected: %.2f%%",
-                   (float)person_pred[0] / 2.55f, (float)car_pred[0] / 2.55f);
+            syslog(LOG_INFO,
+                   "Person detected: %.2f%% - Car detected: %.2f%%",
+                   (float)person_pred[0] / 2.55f,
+                   (float)car_pred[0] / 2.55f);
         } else {
             uint8_t* car_pred        = (uint8_t*)larodOutput1Addr;
             uint8_t* person_pred     = (uint8_t*)larodOutput2Addr;
             float float_score_car    = *((float*)car_pred);
             float float_score_person = *((float*)person_pred);
-            syslog(LOG_INFO, "Person detected: %.2f%% - Car detected: %.2f%%",
-                   float_score_person * 100, float_score_car * 100);
+            syslog(LOG_INFO,
+                   "Person detected: %.2f%% - Car detected: %.2f%%",
+                   float_score_person * 100,
+                   float_score_car * 100);
         }
 
         // Release frame reference to provider.

--- a/vdo-opencl-filtering/app/vdo_cl_filter_demo.c
+++ b/vdo-opencl-filtering/app/vdo_cl_filter_demo.c
@@ -91,8 +91,11 @@ size_t global_work_size[2];
 GHashTable* table = NULL;
 
 static void print_cl_platform_info(cl_platform_id id) {
-    cl_platform_info param_names[] = {CL_PLATFORM_PROFILE, CL_PLATFORM_VERSION, CL_PLATFORM_NAME,
-                                      CL_PLATFORM_VENDOR, CL_PLATFORM_EXTENSIONS};
+    cl_platform_info param_names[] = {CL_PLATFORM_PROFILE,
+                                      CL_PLATFORM_VERSION,
+                                      CL_PLATFORM_NAME,
+                                      CL_PLATFORM_VENDOR,
+                                      CL_PLATFORM_EXTENSIONS};
 
     syslog(LOG_INFO, "Platform info:");
     for (int i = 0; i < 5; i++) {
@@ -126,8 +129,11 @@ static cl_program create_cl_program(cl_context cont, const char* file_name, cl_i
 
     fclose(fp);
 
-    cl_program prog = clCreateProgramWithSource(cont, 1, (const char**)&source_str,
-                                                (const size_t*)&source_size, ret);
+    cl_program prog = clCreateProgramWithSource(cont,
+                                                1,
+                                                (const char**)&source_str,
+                                                (const size_t*)&source_size,
+                                                ret);
     free(source_str);
     return prog;
 }
@@ -163,8 +169,8 @@ static int free_opencl() {
     return 0;
 }
 
-static int setup_opencl(const char* kernel_name, enum render_area area, unsigned width,
-                        unsigned height) {
+static int
+setup_opencl(const char* kernel_name, enum render_area area, unsigned width, unsigned height) {
     cl_int ret = clGetPlatformIDs(1, &platform_id, &ret_num_platforms);
     if (ret != CL_SUCCESS) {
         syslog(LOG_ERR, "Could not get device id's");
@@ -247,8 +253,12 @@ static int setup_opencl(const char* kernel_name, enum render_area area, unsigned
  * For our sobel operations we ignore cbcr values and simply output 128 for all
  * pixels directly in the kernel.
  */
-static int do_opencl_filtering(cl_mem* in_image_y, void* out_data, unsigned width, unsigned height,
-                               size_t image_y_size, size_t image_cbcr_size) {
+static int do_opencl_filtering(cl_mem* in_image_y,
+                               void* out_data,
+                               unsigned width,
+                               unsigned height,
+                               size_t image_y_size,
+                               size_t image_cbcr_size) {
     int ret;
 
     /*
@@ -268,10 +278,16 @@ static int do_opencl_filtering(cl_mem* in_image_y, void* out_data, unsigned widt
      * memory, such that no unnecessary data has to be copied to GPU memory.
      * This data may still however be cached in the GPU.
      */
-    out_image_y    = clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR, image_y_size,
-                                 out_data, &ret);
-    out_image_cbcr = clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
-                                    image_cbcr_size, (out_data + image_y_size), &ret);
+    out_image_y    = clCreateBuffer(context,
+                                 CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
+                                 image_y_size,
+                                 out_data,
+                                 &ret);
+    out_image_cbcr = clCreateBuffer(context,
+                                    CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
+                                    image_cbcr_size,
+                                    (out_data + image_y_size),
+                                    &ret);
     if (ret != CL_SUCCESS) {
         syslog(LOG_ERR, "Unable to create cl memory objects");
         return -1;
@@ -282,8 +298,15 @@ static int do_opencl_filtering(cl_mem* in_image_y, void* out_data, unsigned widt
     ret |= clSetKernelArg(kernel, 2, sizeof(cl_mem), (void*)&out_image_cbcr);
     ret |= clSetKernelArg(kernel, 3, sizeof(width), &width);
     ret |= clSetKernelArg(kernel, 4, sizeof(height), &height);
-    ret |= clEnqueueNDRangeKernel(command_queue, kernel, 2, offset, global_work_size,
-                                  local_work_size, 0, NULL, NULL);
+    ret |= clEnqueueNDRangeKernel(command_queue,
+                                  kernel,
+                                  2,
+                                  offset,
+                                  global_work_size,
+                                  local_work_size,
+                                  0,
+                                  NULL,
+                                  NULL);
 
     ret |= clFinish(command_queue);
     if (ret != CL_SUCCESS) {
@@ -307,8 +330,12 @@ static void hash_table_destroy(void) {
  * Map a VDO buffer address to an OpenCL memory object. If the address has
  * already been mapped, look up the OpenCL memory object in the hash table
  */
-static int map_input_buffer(void* buffer, cl_mem* in_images, cl_mem* in_image_y, size_t image_size,
-                            enum render_area area, unsigned buffer_count) {
+static int map_input_buffer(void* buffer,
+                            cl_mem* in_images,
+                            cl_mem* in_image_y,
+                            size_t image_size,
+                            enum render_area area,
+                            unsigned buffer_count) {
     int ret;
     static unsigned count = 0;
 
@@ -389,7 +416,9 @@ int main(int argc, char* argv[]) {
     vdo_stream_info = vdo_stream_get_info(stream, &error);
     if (!vdo_stream_info) goto exit;
 
-    syslog(LOG_INFO, "Starting stream: %s in %s, %ux%u, %u fps.", output_file_format,
+    syslog(LOG_INFO,
+           "Starting stream: %s in %s, %ux%u, %u fps.",
+           output_file_format,
            vdo_map_get_string(vdo_stream_info, "subformat", NULL, "N/A"),
            vdo_map_get_uint32(vdo_stream_info, "width", 0),
            vdo_map_get_uint32(vdo_stream_info, "height", 0),
@@ -402,7 +431,8 @@ int main(int argc, char* argv[]) {
 
     /* Open output file */
     char file_path[128];
-    snprintf(file_path, sizeof(file_path),
+    snprintf(file_path,
+             sizeof(file_path),
              "/usr/local/packages/"
              "vdo_cl_filter_demo/cl_vdo_demo.%s",
              output_file_format);
@@ -422,8 +452,12 @@ int main(int argc, char* argv[]) {
      * Allocate memory for output buffer. In this case it's more practical with
      * a separate output buffer since we're performing a filtering operation.
      */
-    out_data = mmap(NULL, (image_y_size + image_cbcr_size), PROT_READ | PROT_WRITE,
-                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    out_data = mmap(NULL,
+                    (image_y_size + image_cbcr_size),
+                    PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS,
+                    -1,
+                    0);
     if (out_data == MAP_FAILED) {
         syslog(LOG_ERR, "mmap failed: %d", errno);
         goto exit;
@@ -476,11 +510,19 @@ int main(int argc, char* argv[]) {
          * cl buffer.
          */
         cl_mem in_image_y;
-        if (map_input_buffer(in_data, in_images, &in_image_y, image_y_size, cur_render_area,
+        if (map_input_buffer(in_data,
+                             in_images,
+                             &in_image_y,
+                             image_y_size,
+                             cur_render_area,
                              buffer_count))
             goto exit;
 
-        if (do_opencl_filtering(&in_image_y, out_data, image_width, image_height, image_y_size,
+        if (do_opencl_filtering(&in_image_y,
+                                out_data,
+                                image_width,
+                                image_height,
+                                image_y_size,
                                 image_cbcr_size))
             goto exit;
 

--- a/vdostream/app/vdoencodeclient.c
+++ b/vdostream/app/vdoencodeclient.c
@@ -95,8 +95,11 @@ static void print_frame(VdoFrame* frame) {
             frame_type = "NA";
     }
 
-    syslog(LOG_INFO, "frame = %4u, type = %s, size = %zu\n", vdo_frame_get_sequence_nbr(frame),
-           frame_type, vdo_frame_get_size(frame));
+    syslog(LOG_INFO,
+           "frame = %4u, type = %s, size = %zu\n",
+           vdo_frame_get_sequence_nbr(frame),
+           frame_type,
+           vdo_frame_get_size(frame));
 }
 
 // Set vdo format from input parameter
@@ -114,8 +117,11 @@ static gboolean set_format(VdoMap* settings, gchar* format, GError** error) {
         vdo_map_set_uint32(settings, "format", VDO_FORMAT_YUV);
         vdo_map_set_string(settings, "subformat", "Y800");
     } else {
-        g_set_error(error, VDO_CLIENT_ERROR, VDO_ERROR_NOT_FOUND,
-                    "Format \"%s\" is not supported\n", format);
+        g_set_error(error,
+                    VDO_CLIENT_ERROR,
+                    VDO_ERROR_NOT_FOUND,
+                    "Format \"%s\" is not supported\n",
+                    format);
         return FALSE;
     }
 
@@ -139,7 +145,12 @@ int main(int argc, char* argv[]) {
     openlog(NULL, LOG_PID, LOG_USER);
 
     GOptionEntry options[] = {
-        {"format", 't', 0, G_OPTION_ARG_STRING, &format, "format (h264, h265, jpeg, nv12, y800)",
+        {"format",
+         't',
+         0,
+         G_OPTION_ARG_STRING,
+         &format,
+         "format (h264, h265, jpeg, nv12, y800)",
          NULL},
         {"frames", 'n', 0, G_OPTION_ARG_INT, &frames, "number of frames", NULL},
         {"output", 'o', 0, G_OPTION_ARG_FILENAME, &output_file, "output filename", NULL},
@@ -188,8 +199,11 @@ int main(int argc, char* argv[]) {
     VdoMap* info = vdo_stream_get_info(stream, &error);
     if (!info) goto exit;
 
-    syslog(LOG_INFO, "Starting stream: %s, %ux%u, %u fps\n", format,
-           vdo_map_get_uint32(info, "width", 0), vdo_map_get_uint32(info, "height", 0),
+    syslog(LOG_INFO,
+           "Starting stream: %s, %ux%u, %u fps\n",
+           format,
+           vdo_map_get_uint32(info, "width", 0),
+           vdo_map_get_uint32(info, "height", 0),
            vdo_map_get_uint32(info, "framerate", 0));
 
     g_clear_object(&info);


### PR DESCRIPTION
clang-format options:
  BinPackArguments: false
  AllowAllArgumentsOnNextLine: false
  BinPackParameters: false
  AllowAllParametersOfDeclarationOnNextLine: false
