### PR TITLE
Fix overflow issue

### DIFF
--- a/object-detection/app/object_detection.c
+++ b/object-detection/app/object_detection.c
@@ -171,19 +171,14 @@ static bool parseLabels(char*** labelsPtr,
     labelIdx++;
     for (size_t i = 0; i < labelsFileSize; i++) {
         if (labelsData[i] == '\n') {
-            // Register the string start in the list of labels.
-            labelArray[labelIdx] = labelsData + i + 1;
-            labelIdx++;
+            if (i < (labelsFileSize - 1)) {
+                // Register the string start in the list of labels.
+                labelArray[labelIdx] = labelsData + i + 1;
+                labelIdx++;
+            }
             // Replace the newline char with string-ending NULL char.
             labelsData[i] = '\0';
         }
-    }
-
-    // If the very last byte in the labels file was a new-line we just
-    // replace that with a NULL-char. Refer previous for loop skipping looking
-    // for new-line at the end of file.
-    if (labelsData[labelsFileSize - 1] == '\n') {
-        labelsData[labelsFileSize - 1] = '\0';
     }
 
     // Make sure we always have a terminating NULL char after the label file


### PR DESCRIPTION
### Describe your changes

When assigning pointers to `labelArray`, if the file had a final, empty newline, the last element of `labelArray` would try to be assigned to a pointer to `labelsData + labelsFileSize + 1`, which can cause a warning that can disrupt inference:

```
malloc(): invalid size (unsorted)
```

I also removed the replacement of the final `'\n'` with `'\0'` because it is always done in the loop.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
