### PR TITLE
Fix typo in README.md

### DIFF
--- a/shell-script-example/README.md
+++ b/shell-script-example/README.md
@@ -13,7 +13,7 @@ These instructions will guide you on how to execute the code. Below is the struc
 ```sh
 shell-script-example
 ├── app
-│   ├── shell-script_example.c
+│   ├── shell-script_example
 │   ├── LICENSE
 │   ├── Makefile
 │   └── manifest.json


### PR DESCRIPTION
Remove erroneous '.c' extension from shell_script_example in the first file listing.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
