### PR TITLE
renovate: Skip updates of container-example

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "extends": ["config:base", ":prHourlyLimitNone"],
   "labels": ["dependencies"],
+  "ignorePaths": ["container-example/**"],
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
The version handling would need to be handled in a different way for
renovate to work for the container-example, which right now only update
one file and by that breaks the example.
