### PR TITLE
Lint: Check alignment of super-linter version, Remove renovate config, remove abs path 

### DIFF
--- a/.github/custom-linters/lint-acap-documentation-urls.sh
+++ b/.github/custom-linters/lint-acap-documentation-urls.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "$(pwd)"/.github/utils/util-functions.sh
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
 
 WORKFLOWFILE=${0##*/}
 

--- a/.github/custom-linters/lint-device-urls.sh
+++ b/.github/custom-linters/lint-device-urls.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "$(pwd)"/.github/utils/util-functions.sh
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
 
 #-------------------------------------------------------------------------------
 # Functions

--- a/.github/custom-linters/lint-example-structure.sh
+++ b/.github/custom-linters/lint-example-structure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. "$(pwd)"/.github/utils/util-functions.sh
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
 
 #-------------------------------------------------------------------------------
 # Functions

--- a/.github/custom-linters/lint-super-linter-version.sh
+++ b/.github/custom-linters/lint-super-linter-version.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
+
+#-------------------------------------------------------------------------------
+# Functions
+#-------------------------------------------------------------------------------
+
+check_super_linter_version_aligned_in_all_places() {
+  local ret=0
+  local fail_list=
+  local workflow_dir=.github/workflows
+  local workflow_version=
+  local local_version=
+  local lines_with_super_linter_image=
+  local super_linter_repo=super-linter/super-linter
+  local super_linter_action_name="$super_linter_repo/slim@v"
+  local super_linter_image_name="$super_linter_repo:slim-v"
+  local exclude_list="--exclude-dir=.git"
+
+  print_section "Verify that version of super-linter is aligned in workflow, linters and docs"
+
+  workflow_file_entry="$(cd "$workflow_dir" || print_line "Error: Can't cd to $workflow_dir" && exit 1 |
+                         grep -rnIE $super_linter_action_name $exclude_list)"
+  workflow_version="$(echo "$workflow_file_entry" |
+                      grep -oE '@v[0-9]+' |
+                      grep -oE '[0-9]+')"
+  lines_with_super_linter_image="$(grep -rnIE $super_linter_image_name $exclude_list)"
+  while read -r line; do
+    local_version="$(echo "$line" |
+                     grep -oE '\-v[0-9]+' |
+                     grep -oE '[0-9]+')"
+    [ "$local_version" = "$workflow_version" ] || {
+      fail_list=$(printf '%s\n%s' "$line" "$fail_list")
+    }
+  done <<< "$lines_with_super_linter_image"
+
+  if [ "$fail_list" ]; then
+    print_line "ERROR: Version of super-linter is '$workflow_version' in workflow file"
+    print_line "       \"$workflow_file_entry\""
+    print_line "       The following places need to align super-linter version to the workflow:"
+    print_linebreaked_list_error "$fail_list"
+    ret=1
+  else
+    print_bullet_pass "Version of super-linter is aligned in workflow, linters and docs"
+  fi
+
+  return $ret
+}
+
+#-------------------------------------------------------------------------------
+# Main
+#-------------------------------------------------------------------------------
+
+exit_value=0
+found_error=no
+
+if ! check_super_linter_version_aligned_in_all_places; then found_error=yes; fi
+
+[ "$found_error" = no ] || exit_value=1
+
+exit $exit_value

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,10 +7,6 @@
     "ignorePaths": ["container-example/**"],
     "packageRules": [
         {
-            "groupName": "Update of files using super-linter",
-            "matchFileNames": ["LINT.md", "run-linters", ".github/workflows/linter.y(a)?ml" ]
-        },
-        {
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
             "automerge": true
         },
@@ -19,16 +15,6 @@
             "enabled": false
         }
     ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update super-linter",
-      "fileMatch": ["LINT.md", "run-linters"],
-      "depNameTemplate": "docker",
-      "datasourceTemplate": "docker",
-      "matchStrings": [".*ghcr.io/super-linter/super-linter:(?<currentValue>.*?)\\n"]
-    }
-  ],
     "rebaseWhen": "behind-base-branch",
     "vulnerabilityAlerts": {
         "labels": ["security"]

--- a/.github/run-custom-linters
+++ b/.github/run-custom-linters
@@ -1,9 +1,15 @@
 #! /bin/bash
 
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
+
 exitcode=0
-for linter in .github/custom-linters/*; do
+start_dir=$PWD
+git_top_dir="$(git rev-parse --show-toplevel)"
+custom_linters_dir="$git_top_dir/.github/custom-linters"
+for linter in "$custom_linters_dir"/*; do
   if [ -x "$linter" ]; then
     $linter || exitcode=1
   fi
 done
+cd "$start_dir" || :
 exit $exitcode

--- a/.github/workflows/linter-super-linter-version.yml
+++ b/.github/workflows/linter-super-linter-version.yml
@@ -1,0 +1,22 @@
+name: Check version of super-linter in all places
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    name: Check super-linter version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Verify that super-linter version is aligned to workflow file
+        if: always()
+        run: |
+          .github/custom-linters/lint-super-linter-version.sh

--- a/LINT.md
+++ b/LINT.md
@@ -137,7 +137,7 @@ docker run --rm \
   -v $PWD:/tmp/lint \
   -w /tmp/lint \
   --entrypoint /bin/bash \
-  -it ghcr.io/super-linter/super-linter:slim-v6
+  -it ghcr.io/super-linter/super-linter:slim-v7
 ```
 
 Then from the container terminal, the following commands can lint the codebase
@@ -182,7 +182,7 @@ docker run --rm \
   -v $PWD:/tmp/lint \
   -w /tmp/lint \
   --entrypoint /bin/bash \
-  -it ghcr.io/super-linter/super-linter:slim-v6
+  -it ghcr.io/super-linter/super-linter:slim-v7
 
 # Autoformat C and C++ files (second line change all)
 clang-format -i <path/to/file>
@@ -206,7 +206,7 @@ compatible, but can't be guaranteed.
 
 | super-linter | clang-format | Likely compatible clang-format versions |
 | ------------ | ------------ | --------------------------------------- |
-| slim-v6      | 17           | 15-17                                   |
+| slim-v7      | 17           | 15-17                                   |
 
 If the setup is correct, the extension will automatically format the code
 according to the configuration file on save and when typing.

--- a/run-linters
+++ b/run-linters
@@ -2,7 +2,7 @@
 
 SCRIPT=${0##*/}
 
-. "$(pwd)"/.github/utils/util-functions.sh
+. "$(git rev-parse --show-toplevel)"/.github/utils/util-functions.sh
 
 # Must be run from top directory
 for dir_to_check in .git vdostream; do
@@ -63,7 +63,7 @@ done
     -e RUN_LOCAL=true \
     --env-file .github/super-linter.env \
     -v "$(pwd)":/tmp/lint \
-    -w /tmp/lint ghcr.io/super-linter/super-linter:slim-v6
+    -w /tmp/lint ghcr.io/super-linter/super-linter:slim-v7
   exitcode_super_linter=$?
 }
 


### PR DESCRIPTION
- Use absolute path to git root to make it future-proof
- Remove renovate config to step super linter not working
- Align super-linter versions to workflow
- Add linter to check alignment of super-linter version
