### PR TITLE
reproducible-package: Document permission bits related pitfall

### DIFF
--- a/reproducible-package/README.md
+++ b/reproducible-package/README.md
@@ -19,6 +19,14 @@ and the steps taken in this example are:
 for more complex applications. See the link above for more tips on how to get
 your application reproducible.
 
+> [!IMPORTANT]
+> These instructions may not ensure reproducible builds across different machines.
+> 
+> This is because permission bits are preserved, and different systems may set them differently.
+> For example, executable files — such as shell scripts — and symlinks may have:
+> - `lrwxr-xr-x` on macOS, and
+> - `lrwxrwxrwx` on an Ubuntu GitHub runner.
+
 ## Getting started
 
 Below is the structure and scripts used in the example:


### PR DESCRIPTION
### Describe your changes

This PR adds an alert to the `reproducible-package` readme informing readers of circumstances under which two developers could get different results when following the instructions.

Three factors conspire to make this a realistic pitfall:
1. different systems set different permissions on files
2. the permissions are preserved when copying files into a docker image
3. the permissions are preserved when `acap-build` adds files to an archive

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
