### PR TITLE
fix(object-detection-cv25): Fix broken link in README

### DIFF
--- a/object-detection-cv25/README.md
+++ b/object-detection-cv25/README.md
@@ -40,7 +40,7 @@ The following instructions can be executed to simply run the example.
 
 ## Designing the application
 
-The whole principle is similar to the [vdo-larod-cv25](../vdo-larod-cv25). In this example, the original video stream has a resolution of 640x360, while MobileNet SSD COCO requires an input size of 300x300, so we set up two different streams: one is for MobileNet model, another is used to crop a higher resolution jpg image.
+The whole principle is similar to the [vdo-larod-cv25](../tensorflow-to-larod-cv25). In this example, the original video stream has a resolution of 640x360, while MobileNet SSD COCO requires an input size of 300x300, so we set up two different streams: one is for MobileNet model, another is used to crop a higher resolution jpg image.
 Although the model takes an input of 300x300, the CV25 accelerator expects an input of size multiple of 32. This means that the input needs to be converted to a resolution of 300x320 to satisfy the chip requirements. This is done by adding 20 bytes of padding to each row of the image.
 In general, it would be easier to use a model that has already by design an input of size multiple of 32 (typically 320x320 or 640x640).
 

--- a/object-detection-cv25/README.md
+++ b/object-detection-cv25/README.md
@@ -40,7 +40,7 @@ The following instructions can be executed to simply run the example.
 
 ## Designing the application
 
-The whole principle is similar to the [vdo-larod-cv25](../tensorflow-to-larod-cv25). In this example, the original video stream has a resolution of 640x360, while MobileNet SSD COCO requires an input size of 300x300, so we set up two different streams: one is for MobileNet model, another is used to crop a higher resolution jpg image.
+The whole principle is similar to the [vdo-larod](../vdo-larod). In this example, the original video stream has a resolution of 640x360, while MobileNet SSD COCO requires an input size of 300x300, so we set up two different streams: one is for MobileNet model, another is used to crop a higher resolution jpg image.
 Although the model takes an input of 300x300, the CV25 accelerator expects an input of size multiple of 32. This means that the input needs to be converted to a resolution of 300x320 to satisfy the chip requirements. This is done by adding 20 bytes of padding to each row of the image.
 In general, it would be easier to use a model that has already by design an input of size multiple of 32 (typically 320x320 or 640x640).
 


### PR DESCRIPTION
This reverts the link target to what it was before it was last changed in 6aa62c57b650ab2d76af35c007933a54e9c6f70b. The link target introduced by that commit, does not and has never existed in the repository and, since the context of the link did not change, I assume it should still point to the same example as it used to. But this is not correct:

> It shouldn't link to tesnorflow-to-larod-cv25 either since that is a model training example, not an ACAP application.
