### PR TITLE
Disable renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "timezone": "Europe/Stockholm",
-    "schedule": ["at any time"],
-    "extends": ["config:recommended", ":prHourlyLimitNone"],
-    "configMigration": true,
-    "labels": ["dependencies"],
-    "ignorePaths": ["container-example/**"],
-    "packageRules": [
-        {
-            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-            "automerge": true
-        },
-        {
-            "matchManagers": ["dockerfile"],
-            "enabled": false
-        }
-    ],
-    "rebaseWhen": "behind-base-branch",
-    "vulnerabilityAlerts": {
-        "labels": ["security"]
-    },
-    "minimumReleaseAge": "7 days",
-    "prCreation": "not-pending",
-    "dependencyDashboard": true
+  "enabled": false
 }


### PR DESCRIPTION
### Describe your changes

Renovate is run internally and any accepted updates will be manually updated anyway. 

Keeping renovate running in this repo only creates duplicated PRs and job runs.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
