### PR TITLE
fix: guard destroy-loop dereference of img_info with existing null check

### DIFF
--- a/object-detection-yolov5/app/model.c
+++ b/object-detection-yolov5/app/model.c
@@ -344,13 +344,13 @@ void model_provider_destroy(model_provider_t* provider) {
     if (provider->model_output_tensors) {
         free(provider->model_output_tensors);
     }
-    for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
-        larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
-        if (provider->img_duped_fds[i] >= 0) {
-            close(provider->img_duped_fds[i]);
-        }
-    }
     if (provider->img_info) {
+        for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
+            larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
+            if (provider->img_duped_fds[i] >= 0) {
+                close(provider->img_duped_fds[i]);
+            }
+        }
         free(provider->img_info);
     }
 

--- a/object-detection/app/model.c
+++ b/object-detection/app/model.c
@@ -336,13 +336,13 @@ void model_provider_destroy(model_provider_t* provider) {
     if (provider->model_output_tensors) {
         free(provider->model_output_tensors);
     }
-    for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
-        larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
-        if (provider->img_duped_fds[i] >= 0) {
-            close(provider->img_duped_fds[i]);
-        }
-    }
     if (provider->img_info) {
+        for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
+            larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
+            if (provider->img_duped_fds[i] >= 0) {
+                close(provider->img_duped_fds[i]);
+            }
+        }
         free(provider->img_info);
     }
 

--- a/vdo-larod/app/model.c
+++ b/vdo-larod/app/model.c
@@ -333,13 +333,13 @@ void model_provider_destroy(model_provider_t* provider) {
     if (provider->model_output_tensors) {
         free(provider->model_output_tensors);
     }
-    for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
-        larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
-        if (provider->img_duped_fds[i] >= 0) {
-            close(provider->img_duped_fds[i]);
-        }
-    }
     if (provider->img_info) {
+        for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
+            larodDestroyTensors(provider->conn, &provider->img_input_tensors[i], 1, &error);
+            if (provider->img_duped_fds[i] >= 0) {
+                close(provider->img_duped_fds[i]);
+            }
+        }
         free(provider->img_info);
     }
 


### PR DESCRIPTION
## What

In `model_provider_destroy()`, the cleanup loop iterating over `provider->img_info->nbr_buffers` dereferences `provider->img_info` before the existing `if (provider->img_info)` null check that guards the `free()` call three lines below it:

```c
for (size_t i = 0; i < provider->img_info->nbr_buffers; i++) {
    ...
}
if (provider->img_info) {
    free(provider->img_info);
}
```

This moves the loop inside the same guard, so the dereference and the free are protected by one consistent check instead of two inconsistent ones. The same exact pattern existed identically in three examples (`object-detection`, `object-detection-yolov5`, `vdo-larod`), so this PR fixes all three.

## Why

`cppcheck --enable=warning` flags this as `nullPointerRedundantCheck` in all three files.

## Testing

`cppcheck --enable=warning,performance,portability` no longer reports the null-pointer warning on any of the three files.

Before:
<img width="1760" height="494" alt="pre" src="https://github.com/user-attachments/assets/c7f044ab-a1f0-47e9-afca-3f90513a8697" />

After:
<img width="1340" height="191" alt="post" src="https://github.com/user-attachments/assets/085f0ad2-0de1-447e-8324-0d53f2f5d25c" />