### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/audio-capture.yml
+++ b/.github/workflows/audio-capture.yml
@@ -6,6 +6,9 @@ on:
       - 'audio-capture/**'
       - '!audio-capture/README.md'
       - '.github/workflows/audio-capture.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/audio-playback.yml
+++ b/.github/workflows/audio-playback.yml
@@ -6,6 +6,9 @@ on:
       - 'audio-playback/**'
       - '!audio-playback/README.md'
       - '.github/workflows/audio-playback.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axevent.yml
+++ b/.github/workflows/axevent.yml
@@ -6,6 +6,9 @@ on:
       - 'axevent/**'
       - '!axevent/**/README.md'
       - '.github/workflows/axevent.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axoverlay.yml
+++ b/.github/workflows/axoverlay.yml
@@ -6,6 +6,9 @@ on:
       - 'axoverlay/**'
       - '!axoverlay/README.md'
       - '.github/workflows/axoverlay.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axoverlay2-skia.yml
+++ b/.github/workflows/axoverlay2-skia.yml
@@ -6,6 +6,9 @@ on:
       - 'axoverlay2-skia/**'
       - '!axoverlay2-skia/README.md'
       - '.github/workflows/axoverlay2-skia.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axoverlay2.yml
+++ b/.github/workflows/axoverlay2.yml
@@ -6,6 +6,9 @@ on:
       - 'axoverlay2/**'
       - '!axoverlay2/README.md'
       - '.github/workflows/axoverlay2.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axparameter.yml
+++ b/.github/workflows/axparameter.yml
@@ -6,6 +6,9 @@ on:
       - 'axparameter/**'
       - '!axparameter/README.md'
       - '.github/workflows/axparameter.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axserialport.yml
+++ b/.github/workflows/axserialport.yml
@@ -6,6 +6,9 @@ on:
       - 'axserialport/**'
       - '!axserialport/README.md'
       - '.github/workflows/axserialport.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/axstorage.yml
+++ b/.github/workflows/axstorage.yml
@@ -6,6 +6,9 @@ on:
       - 'axstorage/**'
       - '!axstorage/README.md'
       - '.github/workflows/axstorage.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/bounding-box.yml
+++ b/.github/workflows/bounding-box.yml
@@ -6,6 +6,9 @@ on:
       - 'bounding-box/**'
       - '!bounding-box/README.md'
       - '.github/workflows/bounding-box.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/container-example.yml
+++ b/.github/workflows/container-example.yml
@@ -6,6 +6,9 @@ on:
       - "container-example/**"
       - "!container-example/README.md"
       - ".github/workflows/container-example.yml"
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/curl-openssl.yml
+++ b/.github/workflows/curl-openssl.yml
@@ -6,6 +6,9 @@ on:
       - 'curl-openssl/**'
       - '!curl-openssl/README.md'
       - '.github/workflows/curl-openssl.yml'
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/device-data-hub.yml
+++ b/.github/workflows/device-data-hub.yml
@@ -6,6 +6,9 @@ on:
       - 'device-data-hub/**'
       - '!device-data-hub/README.md'
       - '.github/workflows/device-data-hub.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -6,6 +6,9 @@ on:
       - 'hello-world/**'
       - '!hello-world/README.md'
       - '.github/workflows/hello-world.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/http-requests-using-fastcgi.yml
+++ b/.github/workflows/http-requests-using-fastcgi.yml
@@ -6,6 +6,9 @@ on:
       - 'web-server/http-requests-using-fastcgi/**'
       - '!web-server/http-requests-using-fastcgi/README.md'
       - '.github/workflows/http-requests-using-fastcgi.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/licensekey.yml
+++ b/.github/workflows/licensekey.yml
@@ -6,6 +6,9 @@ on:
       - 'licensekey/**'
       - '!licensekey/README.md'
       - '.github/workflows/licensekey.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/linter-documentation-links.yml
+++ b/.github/workflows/linter-documentation-links.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Documentation checks

--- a/.github/workflows/linter-example-checks.yml
+++ b/.github/workflows/linter-example-checks.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Example repository checks

--- a/.github/workflows/linter-renovate-config.yml
+++ b/.github/workflows/linter-renovate-config.yml
@@ -7,6 +7,9 @@ on:
       - '.github/renovate.json'
       - '.github/workflows/linter-renovate-config.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint Renovate config file

--- a/.github/workflows/linter-super-linter-version.yml
+++ b/.github/workflows/linter-super-linter-version.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Check super-linter version

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint Code Base

--- a/.github/workflows/message-broker.yml
+++ b/.github/workflows/message-broker.yml
@@ -6,6 +6,9 @@ on:
       - 'message-broker/**'
       - '!message-broker/README.md'
       - '.github/workflows/message-broker.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/object-detection-cv25.yml
+++ b/.github/workflows/object-detection-cv25.yml
@@ -6,6 +6,9 @@ on:
       - 'object-detection-cv25/**'
       - '!object-detection-cv25/README.md'
       - '.github/workflows/object-detection-cv25.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/object-detection-yolov5.yml
+++ b/.github/workflows/object-detection-yolov5.yml
@@ -6,6 +6,9 @@ on:
       - 'object-detection-yolov5/**'
       - '!object-detection-yolov5/README.md'
       - '.github/workflows/object-detection-yolov5.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/object-detection.yml
+++ b/.github/workflows/object-detection.yml
@@ -6,6 +6,9 @@ on:
       - 'object-detection/**'
       - '!object-detection/README.md'
       - '.github/workflows/object-detection.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/ptz-control-ws-api.yml
+++ b/.github/workflows/ptz-control-ws-api.yml
@@ -6,6 +6,9 @@ on:
       - 'ptz-control-ws-api/**'
       - '!ptz-control-ws-api/README.md'
       - '.github/workflows/ptz-control-ws-api.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/recording-playback.yml
+++ b/.github/workflows/recording-playback.yml
@@ -6,6 +6,9 @@ on:
       - 'recording-playback/**'
       - '!recording-playback/README.md'
       - '.github/workflows/recording-playback.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/remote-debug-example.yml
+++ b/.github/workflows/remote-debug-example.yml
@@ -6,6 +6,9 @@ on:
       - 'remote-debug-example/**'
       - '!remote-debug-example/README.md'
       - '.github/workflows/remote-debug-example.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/reproducible-package.yml
+++ b/.github/workflows/reproducible-package.yml
@@ -6,6 +6,9 @@ on:
       - 'reproducible-package/**'
       - '!reproducible-package/README.md'
       - '.github/workflows/reproducible-package.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/reverse-proxy-using-fixed-port.yml
+++ b/.github/workflows/reverse-proxy-using-fixed-port.yml
@@ -6,6 +6,9 @@ on:
       - 'web-server/reverse-proxy-using-fixed-port/**'
       - '!web-server/reverse-proxy-using-fixed-port/README.md'
       - '.github/workflows/reverse-proxy-using-fixed-port.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/shell-script-example.yml
+++ b/.github/workflows/shell-script-example.yml
@@ -6,6 +6,9 @@ on:
       - 'shell-script-example/**'
       - '!shell-script-example/README.md'
       - '.github/workflows/shell-script-example.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/tensorflow-to-larod-artpec8.yml
+++ b/.github/workflows/tensorflow-to-larod-artpec8.yml
@@ -6,6 +6,9 @@ on:
       - 'tensorflow-to-larod-artpec8/**'
       - '!tensorflow-to-larod-artpec8/README.md'
       - '.github/workflows/tensorflow-to-larod-artpec8.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/tensorflow-to-larod-artpec9.yml
+++ b/.github/workflows/tensorflow-to-larod-artpec9.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - 'dummy-branch-that-does-not-exist'
 
+permissions:
+  contents: read
+
 jobs:
   dummy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tensorflow-to-larod-cv25.yml
+++ b/.github/workflows/tensorflow-to-larod-cv25.yml
@@ -6,6 +6,9 @@ on:
       - 'tensorflow-to-larod-cv25/**'
       - '!tensorflow-to-larod-cv25/README.md'
       - '.github/workflows/tensorflow-to-larod-cv25.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/tensorflow-to-larod.yml
+++ b/.github/workflows/tensorflow-to-larod.yml
@@ -6,6 +6,9 @@ on:
       - 'tensorflow-to-larod/**'
       - '!tensorflow-to-larod/README.md'
       - '.github/workflows/tensorflow-to-larod.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/using-opencv.yml
+++ b/.github/workflows/using-opencv.yml
@@ -6,6 +6,9 @@ on:
       - 'using-opencv/**'
       - '!using-opencv/README.md'
       - '.github/workflows/using-opencv.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/utility-libraries.yml
+++ b/.github/workflows/utility-libraries.yml
@@ -6,6 +6,9 @@ on:
       - 'utility-libraries/**'
       - '!utility-libraries/**/README.md'
       - '.github/workflows/utility-libraries.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/vapix.yml
+++ b/.github/workflows/vapix.yml
@@ -6,6 +6,9 @@ on:
       - 'vapix/**'
       - '!vapix/README.md'
       - '.github/workflows/vapix.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/vdo-larod.yml
+++ b/.github/workflows/vdo-larod.yml
@@ -6,6 +6,9 @@ on:
       - 'vdo-larod/**'
       - '!vdo-larod/README.md'
       - '.github/workflows/vdo-larod.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/vdo-opencl-filtering.yml
+++ b/.github/workflows/vdo-opencl-filtering.yml
@@ -6,6 +6,9 @@ on:
       - 'vdo-opencl-filtering/**'
       - '!vdo-opencl-filtering/README.md'
       - '.github/workflows/vdo-opencl-filtering.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app

--- a/.github/workflows/vdostream.yml
+++ b/.github/workflows/vdostream.yml
@@ -6,6 +6,9 @@ on:
       - 'vdostream/**'
       - '!vdostream/README.md'
       - '.github/workflows/vdostream.yml'
+permissions:
+  contents: read
+
 jobs:
   test-app:
     name: Test app


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/audio-capture.yml`
- `.github/workflows/audio-playback.yml`
- `.github/workflows/axevent.yml`
- `.github/workflows/axoverlay.yml`
- `.github/workflows/axoverlay2-skia.yml`
- `.github/workflows/axoverlay2.yml`
- `.github/workflows/axparameter.yml`
- `.github/workflows/axserialport.yml`
- `.github/workflows/axstorage.yml`
- `.github/workflows/bounding-box.yml`
- `.github/workflows/container-example.yml`
- `.github/workflows/curl-openssl.yml`
- `.github/workflows/device-data-hub.yml`
- `.github/workflows/hello-world.yml`
- `.github/workflows/http-requests-using-fastcgi.yml`
- `.github/workflows/licensekey.yml`
- `.github/workflows/linter-documentation-links.yml`
- `.github/workflows/linter-example-checks.yml`
- `.github/workflows/linter-renovate-config.yml`
- `.github/workflows/linter-super-linter-version.yml`
- `.github/workflows/linter.yml`
- `.github/workflows/message-broker.yml`
- `.github/workflows/object-detection-cv25.yml`
- `.github/workflows/object-detection-yolov5.yml`
- `.github/workflows/object-detection.yml`
- `.github/workflows/ptz-control-ws-api.yml`
- `.github/workflows/recording-playback.yml`
- `.github/workflows/remote-debug-example.yml`
- `.github/workflows/reproducible-package.yml`
- `.github/workflows/reverse-proxy-using-fixed-port.yml`
- `.github/workflows/shell-script-example.yml`
- `.github/workflows/tensorflow-to-larod-artpec8.yml`
- `.github/workflows/tensorflow-to-larod-artpec9.yml`
- `.github/workflows/tensorflow-to-larod-cv25.yml`
- `.github/workflows/tensorflow-to-larod.yml`
- `.github/workflows/using-opencv.yml`
- `.github/workflows/utility-libraries.yml`
- `.github/workflows/vapix.yml`
- `.github/workflows/vdo-larod.yml`
- `.github/workflows/vdo-opencl-filtering.yml`
- `.github/workflows/vdostream.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.