### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audio-capture.yml
+++ b/.github/workflows/audio-capture.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: audio-capture
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/audio-playback.yml
+++ b/.github/workflows/audio-playback.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: audio-playback
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axevent.yml
+++ b/.github/workflows/axevent.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axevent
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/axoverlay.yml
+++ b/.github/workflows/axoverlay.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axoverlay
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axoverlay2-skia.yml
+++ b/.github/workflows/axoverlay2-skia.yml
@@ -19,8 +19,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axoverlay2-skia
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axoverlay2.yml
+++ b/.github/workflows/axoverlay2.yml
@@ -19,8 +19,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axoverlay2
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axparameter.yml
+++ b/.github/workflows/axparameter.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axparameter
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axserialport.yml
+++ b/.github/workflows/axserialport.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axserialport
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/axstorage.yml
+++ b/.github/workflows/axstorage.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: axstorage
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/bounding-box.yml
+++ b/.github/workflows/bounding-box.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: bounding-box
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/container-example.yml
+++ b/.github/workflows/container-example.yml
@@ -20,8 +20,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: container-example
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/curl-openssl.yml
+++ b/.github/workflows/curl-openssl.yml
@@ -17,8 +17,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: curl-openssl
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/device-data-hub.yml
+++ b/.github/workflows/device-data-hub.yml
@@ -19,8 +19,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: device-data-hub
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: hello-world
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/http-requests-using-fastcgi.yml
+++ b/.github/workflows/http-requests-using-fastcgi.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: web-server/http-requests-using-fastcgi
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/licensekey.yml
+++ b/.github/workflows/licensekey.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: licensekey
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/linter-documentation-links.yml
+++ b/.github/workflows/linter-documentation-links.yml
@@ -14,8 +14,8 @@ jobs:
     name: Documentation checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Verify that device URLs are consistent
         if: always()

--- a/.github/workflows/linter-example-checks.yml
+++ b/.github/workflows/linter-example-checks.yml
@@ -14,8 +14,8 @@ jobs:
     name: Example repository checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Verify that all examples have expected structure
         if: always()

--- a/.github/workflows/linter-renovate-config.yml
+++ b/.github/workflows/linter-renovate-config.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint Renovate config file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/linter-super-linter-version.yml
+++ b/.github/workflows/linter-super-linter-version.yml
@@ -14,8 +14,8 @@ jobs:
     name: Check super-linter version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Verify that super-linter version is aligned to workflow file
         if: always()
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/message-broker.yml
+++ b/.github/workflows/message-broker.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: message-broker
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/object-detection-cv25.yml
+++ b/.github/workflows/object-detection-cv25.yml
@@ -20,8 +20,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: object-detection-cv25
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/object-detection-yolov5.yml
+++ b/.github/workflows/object-detection-yolov5.yml
@@ -26,8 +26,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: object-detection-yolov5
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/object-detection.yml
+++ b/.github/workflows/object-detection.yml
@@ -29,8 +29,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: object-detection
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/ptz-control-ws-api.yml
+++ b/.github/workflows/ptz-control-ws-api.yml
@@ -19,8 +19,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: ptz-control-ws-api
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/recording-playback.yml
+++ b/.github/workflows/recording-playback.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: recording-playback
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/remote-debug-example.yml
+++ b/.github/workflows/remote-debug-example.yml
@@ -19,8 +19,8 @@ jobs:
       EXNAME: remote-debug-example
       GDBSERVER: gdbserver
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application and dev container
         env:

--- a/.github/workflows/reproducible-package.yml
+++ b/.github/workflows/reproducible-package.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         arch: ["armv7hf", "aarch64"]
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build and test reproducible package application
         run: |
           found_error=n

--- a/.github/workflows/reverse-proxy-using-fixed-port.yml
+++ b/.github/workflows/reverse-proxy-using-fixed-port.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: web-server/reverse-proxy-using-fixed-port
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/shell-script-example.yml
+++ b/.github/workflows/shell-script-example.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: shell-script-example
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/tensorflow-to-larod-artpec8.yml
+++ b/.github/workflows/tensorflow-to-larod-artpec8.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: tensorflow-to-larod-artpec8
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/tensorflow-to-larod-cv25.yml
+++ b/.github/workflows/tensorflow-to-larod-cv25.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: tensorflow-to-larod-cv25
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/tensorflow-to-larod.yml
+++ b/.github/workflows/tensorflow-to-larod.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: tensorflow-to-larod
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/using-opencv.yml
+++ b/.github/workflows/using-opencv.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: using-opencv
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/utility-libraries.yml
+++ b/.github/workflows/utility-libraries.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: utility-libraries
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/vapix.yml
+++ b/.github/workflows/vapix.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: vapix
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/vdo-larod.yml
+++ b/.github/workflows/vdo-larod.yml
@@ -32,8 +32,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: vdo-larod
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.example }} application
         env:

--- a/.github/workflows/vdo-opencl-filtering.yml
+++ b/.github/workflows/vdo-opencl-filtering.yml
@@ -18,8 +18,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: vdo-opencl-filtering
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:

--- a/.github/workflows/vdostream.yml
+++ b/.github/workflows/vdostream.yml
@@ -36,8 +36,8 @@ jobs:
       EXREPO: acap-native-examples
       EXNAME: vdostream
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build ${{ env.EXNAME }} application
         env:


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/audio-capture.yml`
- `.github/workflows/audio-playback.yml`
- `.github/workflows/axevent.yml`
- `.github/workflows/axoverlay.yml`
- `.github/workflows/axoverlay2-skia.yml`
- `.github/workflows/axoverlay2.yml`
- `.github/workflows/axparameter.yml`
- `.github/workflows/axserialport.yml`
- `.github/workflows/axstorage.yml`
- `.github/workflows/bounding-box.yml`
- `.github/workflows/container-example.yml`
- `.github/workflows/curl-openssl.yml`
- `.github/workflows/device-data-hub.yml`
- `.github/workflows/hello-world.yml`
- `.github/workflows/http-requests-using-fastcgi.yml`
- `.github/workflows/licensekey.yml`
- `.github/workflows/linter-documentation-links.yml`
- `.github/workflows/linter-example-checks.yml`
- `.github/workflows/linter-renovate-config.yml`
- `.github/workflows/linter-super-linter-version.yml`
- `.github/workflows/linter.yml`
- `.github/workflows/message-broker.yml`
- `.github/workflows/object-detection-cv25.yml`
- `.github/workflows/object-detection-yolov5.yml`
- `.github/workflows/object-detection.yml`
- `.github/workflows/ptz-control-ws-api.yml`
- `.github/workflows/recording-playback.yml`
- `.github/workflows/remote-debug-example.yml`
- `.github/workflows/reproducible-package.yml`
- `.github/workflows/reverse-proxy-using-fixed-port.yml`
- `.github/workflows/shell-script-example.yml`
- `.github/workflows/tensorflow-to-larod-artpec8.yml`
- `.github/workflows/tensorflow-to-larod-cv25.yml`
- `.github/workflows/tensorflow-to-larod.yml`
- `.github/workflows/using-opencv.yml`
- `.github/workflows/utility-libraries.yml`
- `.github/workflows/vapix.yml`
- `.github/workflows/vdo-larod.yml`
- `.github/workflows/vdo-opencl-filtering.yml`
- `.github/workflows/vdostream.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.